### PR TITLE
Use @playcanvas/observer for dependencies

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,20 +7,14 @@
         "browser": true,
         "es6": true
     },
-    "parser": "babel-eslint",
+    "parser": "@babel/eslint-parser",
     "parserOptions": {
         "ecmaVersion": 11,
         "ecmaFeatures": {
             "jsx": true
         },
-        "sourceType": "module"
-    },
-    "globals": {
-        "Observer": false,
-        "ObserverHistory": false,
-        "ObserverList": false,
-        "ObserverSync": false,
-        "Events": false
+        "sourceType": "module",
+        "requireConfigFile": false
     },
     "rules": {
         "brace-style": [

--- a/index.js
+++ b/index.js
@@ -16,4 +16,3 @@ export * from './src/realtime/scenes';
 export * from './src/realtime/asset';
 export * from './src/realtime/assets';
 export * from './src/realtime';
-export { Events } from './src/pcui';

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,54 @@
         "@babel/highlight": "^7.14.5"
       }
     },
+    "@babel/compat-data": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
+      "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
+      "dev": true
+    },
+    "@babel/core": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
+      "integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.14.5",
+        "@babel/generator": "^7.15.0",
+        "@babel/helper-compilation-targets": "^7.15.0",
+        "@babel/helper-module-transforms": "^7.15.0",
+        "@babel/helpers": "^7.14.8",
+        "@babel/parser": "^7.15.0",
+        "@babel/template": "^7.14.5",
+        "@babel/traverse": "^7.15.0",
+        "@babel/types": "^7.15.0",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.1.2",
+        "semver": "^6.3.0",
+        "source-map": "^0.5.0"
+      }
+    },
+    "@babel/eslint-parser": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.15.0.tgz",
+      "integrity": "sha512-+gSPtjSBxOZz4Uh8Ggqu7HbfpB8cT1LwW0DnVVLZEJvzXauiD0Di3zszcBkRmfGGrLdYeHUwcflG7i3tr9kQlw==",
+      "dev": true,
+      "requires": {
+        "eslint-scope": "^5.1.1",
+        "eslint-visitor-keys": "^2.1.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        }
+      }
+    },
     "@babel/generator": {
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
@@ -22,6 +70,18 @@
         "@babel/types": "^7.15.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz",
+      "integrity": "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.15.0",
+        "@babel/helper-validator-option": "^7.14.5",
+        "browserslist": "^4.16.6",
+        "semver": "^6.3.0"
       }
     },
     "@babel/helper-function-name": {
@@ -53,6 +113,70 @@
         "@babel/types": "^7.14.5"
       }
     },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
+      "integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.15.0"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
+      "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.14.5"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz",
+      "integrity": "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.14.5",
+        "@babel/helper-replace-supers": "^7.15.0",
+        "@babel/helper-simple-access": "^7.14.8",
+        "@babel/helper-split-export-declaration": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/template": "^7.14.5",
+        "@babel/traverse": "^7.15.0",
+        "@babel/types": "^7.15.0"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
+      "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.14.5"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
+      "integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.15.0",
+        "@babel/helper-optimise-call-expression": "^7.14.5",
+        "@babel/traverse": "^7.15.0",
+        "@babel/types": "^7.15.0"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.14.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
+      "integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.14.8"
+      }
+    },
     "@babel/helper-split-export-declaration": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
@@ -67,6 +191,23 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
       "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
       "dev": true
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+      "dev": true
+    },
+    "@babel/helpers": {
+      "version": "7.15.3",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.3.tgz",
+      "integrity": "sha512-HwJiz52XaS96lX+28Tnbu31VeFSQJGOeKHJeaEPQlTl7PnlhFElWPj8tUXtqFIzeN86XxXoBr+WFAyK2PPVz6g==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.14.5",
+        "@babel/traverse": "^7.15.0",
+        "@babel/types": "^7.15.0"
+      }
     },
     "@babel/highlight": {
       "version": "7.14.5",
@@ -161,10 +302,11 @@
         "eslint-plugin-jsdoc": "^27.1.2"
       }
     },
-    "@playcanvas/pcui": {
-      "version": "1.1.23",
-      "resolved": "https://registry.npmjs.org/@playcanvas/pcui/-/pcui-1.1.23.tgz",
-      "integrity": "sha512-/7ejrCVMG+RcTroARd6CWF3ZfpE8T0uYbzO6RC63IxMrJaTMEkYIPygSYntzGl0E29sFT/dnl5KZvirkQWqAog=="
+    "@playcanvas/observer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@playcanvas/observer/-/observer-1.1.0.tgz",
+      "integrity": "sha512-P4R54kLPJxyjE5gSogCNM7eF23F4sN0eu6/YzwRzFYqhJFm3FKC6fQ++vKY+HEY7AyI/XoGoMY4XLMtXKE8/sQ==",
+      "dev": true
     },
     "@sinonjs/commons": {
       "version": "1.8.3",
@@ -220,9 +362,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.6.2.tgz",
-      "integrity": "sha512-LSw8TZt12ZudbpHc6EkIyDM3nHVWKYrAvGy6EAJfNfjusbwnThqjqxUKKRwuV3iWYeW/LYMzNgaq3MaLffQ2xA==",
+      "version": "16.7.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.10.tgz",
+      "integrity": "sha512-S63Dlv4zIPb8x6MMTgDq5WWRJQe56iBEY0O3SOFA9JrRienkOVDXSXBjjJw6HTNQYSE2JI6GMCR6LVbIMHJVvA==",
       "dev": true
     },
     "@ungap/promise-all-settled": {
@@ -317,20 +459,6 @@
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
-    "babel-eslint": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
-      }
-    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -415,6 +543,19 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "browserslist": {
+      "version": "4.16.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
+      "integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001251",
+        "colorette": "^1.3.0",
+        "electron-to-chromium": "^1.3.811",
+        "escalade": "^3.1.1",
+        "node-releases": "^1.1.75"
+      }
+    },
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
@@ -431,6 +572,12 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
       "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001252",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
+      "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
       "dev": true
     },
     "chai": {
@@ -506,6 +653,12 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "colorette": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
+      "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
+      "dev": true
+    },
     "colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
@@ -564,6 +717,23 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
+      }
     },
     "cookie": {
       "version": "0.4.1",
@@ -679,6 +849,12 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
+    "electron-to-chromium": {
+      "version": "1.3.827",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.827.tgz",
+      "integrity": "sha512-ye+4uQOY/jbjRutMcE/EmOcNwUeo1qo9aKL2tPyb09cU3lmxNeyDF4RWiemmkknW+p29h7dyDqy02higTxc9/A==",
+      "dev": true
+    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -707,9 +883,9 @@
       }
     },
     "engine.io-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.2.tgz",
-      "integrity": "sha512-sHfEQv6nmtJrq6TKuIz5kyEKH/qSdK56H/A+7DnAuUPWosnIZAS2NHNcPLmyjtY3cGS/MqJdZbUjW97JU72iYg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
+      "integrity": "sha512-xEAAY0msNnESNPc00e19y5heTPX4y/TJ36gr8t1voOaNmTojP9b3oK3BbJLFufW2XFPQaaijpFewm2g2Um3uqA==",
       "dev": true,
       "requires": {
         "base64-arraybuffer": "0.1.4"
@@ -1113,16 +1289,16 @@
       "dev": true,
       "optional": true
     },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
-    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true
     },
     "get-caller-file": {
@@ -1197,15 +1373,6 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
-      }
-    },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1"
       }
     },
     "has-flag": {
@@ -1306,15 +1473,6 @@
       "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
-      }
-    },
-    "is-core-module": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
-      "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.3"
       }
     },
     "is-extglob": {
@@ -1656,9 +1814,9 @@
       "dev": true
     },
     "marked": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
-      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.2.tgz",
+      "integrity": "sha512-TMJQQ79Z0e3rJYazY0tIoMsFzteUGw9fB3FD+gzuIT3zLuG9L9ckIvUfF51apdJkcqc208jJN2KbtPbOvXtbjA==",
       "dev": true
     },
     "media-typer": {
@@ -1704,9 +1862,9 @@
       "dev": true
     },
     "mocha": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.0.3.tgz",
-      "integrity": "sha512-hnYFrSefHxYS2XFGtN01x8un0EwNu2bzKvhpRFhgoybIvMaOkkL60IVPmkb5h6XDmUl4IMSB+rT5cIO4/4bJgg==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-0wE74YMgOkCgBUj8VyIDwmLUjTsS13WV1Pg7l0SHea2qzZzlq7MDnfbPsHKcELBRk3+izEVkRofjmClpycudCA==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
@@ -1846,6 +2004,12 @@
         "path-to-regexp": "^1.7.0"
       }
     },
+    "node-releases": {
+      "version": "1.1.75",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
+      "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
+      "dev": true
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -1967,12 +2131,6 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
-    "path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
-    },
     "path-to-regexp": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
@@ -2090,16 +2248,6 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
-    "resolve": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-      "dev": true,
-      "requires": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
-      }
-    },
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2122,9 +2270,9 @@
       }
     },
     "rollup": {
-      "version": "2.56.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.2.tgz",
-      "integrity": "sha512-s8H00ZsRi29M2/lGdm1u8DJpJ9ML8SUOpVVBd33XNeEeL3NVaTiUcSBHzBdF3eAyR0l7VSpsuoVUGrRHq7aPwQ==",
+      "version": "2.56.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.3.tgz",
+      "integrity": "sha512-Au92NuznFklgQCUcV96iXlxUbHuB1vQMaH76DHl5M11TotjOHwqk9CwcrT78+Tnv4FN9uTBxq6p4EJoYkpyekg==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -2179,9 +2327,9 @@
       "dev": true
     },
     "shiki": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.7.tgz",
-      "integrity": "sha512-rOoAmwRWDiGKjQ1GaSKmbp1J5CamCera+I+DMM3wG/phbwNYQPt1mrjBBZbK66v80Vl1/A9TTLgXVHMbgtOCIQ==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.10.tgz",
+      "integrity": "sha512-xeM7Oc6hY+6iW5O/T5hor8ul7mEprzyl5y4r5zthEHToQNw7MIhREMgU3r2gKDB0NaMLNrkcEQagudCdzE13Lg==",
       "dev": true,
       "requires": {
         "json5": "^2.2.0",
@@ -2487,18 +2635,18 @@
       }
     },
     "typedoc": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.21.6.tgz",
-      "integrity": "sha512-+4u3PEBjQdaL5/yfus5WJbjIdQHv7E/FpZq3cNki9BBdGmZhqnTF6JLIXDQ2EfVggojOJG9/soB5QVFgXRYnIw==",
+      "version": "0.21.9",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.21.9.tgz",
+      "integrity": "sha512-VRo7aII4bnYaBBM1lhw4bQFmUcDQV8m8tqgjtc7oXl87jc1Slbhfw2X5MccfcR2YnEClHDWgsiQGgNB8KJXocA==",
       "dev": true,
       "requires": {
         "glob": "^7.1.7",
         "handlebars": "^4.7.7",
         "lunr": "^2.3.9",
-        "marked": "^2.1.1",
+        "marked": "^3.0.2",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
-        "shiki": "^0.9.3",
+        "shiki": "^0.9.8",
         "typedoc-default-themes": "^0.12.10"
       }
     },
@@ -2518,9 +2666,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "The PlayCanvas Editor API",
   "main": "index.js",
+  "module": "index.mjs",
   "scripts": {
     "test": "karma start test/karma.conf.js --single-run",
     "test:debug": "karma start test/karma.conf.js --single-run=false --browsers Chrome",
@@ -21,8 +22,10 @@
   },
   "homepage": "https://github.com/playcanvas/editor-api#readme",
   "devDependencies": {
+    "@babel/core": "^7.15.0",
+    "@babel/eslint-parser": "^7.15.0",
     "@playcanvas/eslint-config": "1.0.6",
-    "babel-eslint": "^10.1.0",
+    "@playcanvas/observer": "1.1.0",
     "chai": "4.3.4",
     "eslint": "7.19.0",
     "karma": "^6.3.4",
@@ -35,8 +38,5 @@
     "typedoc": "^0.21.4",
     "typedoc-plugin-markdown": "^3.10.4",
     "typescript": "^4.3.5"
-  },
-  "dependencies": {
-    "@playcanvas/pcui": "^1.1.23"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,14 +1,26 @@
-const api = {
+const umd = {
+    external: ['@playcanvas/observer'],
     input: 'index.js',
     output: {
-        file: 'dist/api.js',
+        file: 'dist/index.js',
         format: 'umd',
-        name: 'api'
+        name: 'api',
+        globals: {
+            '@playcanvas/observer': 'observer'
+        }
     }
 };
 
-let targets = [
-    api
-];
+const module = {
+    external: ['@playcanvas/observer'],
+    input: 'index.js',
+    output: {
+        file: 'dist/index.mjs',
+        format: 'module',
+        globals: {
+            '@playcanvas/observer': 'observer'
+        }
+    }
+};
 
-export default targets;
+export default [umd, module];

--- a/src/asset.js
+++ b/src/asset.js
@@ -1,5 +1,5 @@
 import { globals as api } from './globals';
-import { Events } from './pcui';
+import { Events, Observer, ObserverHistory } from '@playcanvas/observer';
 
 /**
  * Represents an Asset

--- a/src/assets.js
+++ b/src/assets.js
@@ -1,6 +1,6 @@
 import { Asset } from './asset';
 import { globals as api } from './globals';
-import { Events } from './pcui';
+import { Events, ObserverList } from '@playcanvas/observer';
 import { uploadFile } from './assets/upload';
 import { createTemplate } from './assets/createTemplate';
 import { createScript } from './assets/createScript';

--- a/src/entities.js
+++ b/src/entities.js
@@ -1,6 +1,6 @@
 import { globals as api } from './globals';
 import { Entity } from './entity';
-import { Events } from './pcui';
+import { Events, ObserverList } from '@playcanvas/observer';
 import { createEntity } from './entities/create';
 import { duplicateEntities } from './entities/duplicate';
 import { reparentEntities } from './entities/reparent';

--- a/src/entity.js
+++ b/src/entity.js
@@ -1,5 +1,5 @@
 import { globals as api } from './globals';
-import { Events } from './pcui';
+import { Events, Observer, ObserverHistory } from '@playcanvas/observer';
 
 /**
  * Represents an Entity

--- a/src/history.js
+++ b/src/history.js
@@ -1,4 +1,4 @@
-import { Events, History as pcuiHistory } from './pcui';
+import { Events, History as apiHistory } from '@playcanvas/observer';
 
 /**
  * A history action
@@ -20,7 +20,7 @@ class History extends Events {
      */
     constructor() {
         super();
-        this._history = new pcuiHistory();
+        this._history = new apiHistory();
         this._history.on('add', name => this.emit('add', name));
         this._history.on('undo', name => this.emit('undo', name));
         this._history.on('redo', name => this.emit('redo', name));

--- a/src/pcui.js
+++ b/src/pcui.js
@@ -1,4 +1,0 @@
-export {
-    History,
-    Events
-} from '../node_modules/@playcanvas/pcui/pcui-binding.mjs';

--- a/src/realtime.js
+++ b/src/realtime.js
@@ -1,7 +1,7 @@
 import { RealtimeConnection } from './realtime/connection';
 import { RealtimeScenes } from './realtime/scenes';
 import { RealtimeAssets } from './realtime/assets';
-import { Events } from './pcui';
+import { Events } from '@playcanvas/observer';
 
 /**
  * Provides methods to communicate and load / save data to the realtime server

--- a/src/realtime/asset.js
+++ b/src/realtime/asset.js
@@ -1,4 +1,4 @@
-import { Events } from '../pcui';
+import { Events } from '@playcanvas/observer';
 
 /**
  * Represents an asset in sharedb

--- a/src/realtime/assets.js
+++ b/src/realtime/assets.js
@@ -1,5 +1,6 @@
-import { Events } from '../pcui';
 import { RealtimeAsset } from './asset';
+import { globals as api } from '../globals';
+import { Events } from '@playcanvas/observer';
 
 /**
  * Provides methods to load assets from sharedb

--- a/src/realtime/connection.js
+++ b/src/realtime/connection.js
@@ -1,5 +1,5 @@
 import { globals as api } from '../globals';
-import { Events } from '../pcui';
+import { Events } from '@playcanvas/observer';
 
 const RECONNECT_INTERVAL = 3;
 const MAX_ATTEMPTS = 3;

--- a/src/realtime/scene.js
+++ b/src/realtime/scene.js
@@ -1,4 +1,4 @@
-import { Events } from '../pcui';
+import { Events } from '@playcanvas/observer';
 
 /**
  * Represents a scene in sharedb

--- a/src/realtime/scenes.js
+++ b/src/realtime/scenes.js
@@ -1,5 +1,5 @@
 import { RealtimeScene } from './scene';
-import { Events } from '../pcui';
+import { Events } from '@playcanvas/observer';
 
 /**
  * Provides methods to load scenes from sharedb

--- a/src/selection.js
+++ b/src/selection.js
@@ -1,5 +1,5 @@
 import { globals as api } from './globals';
-import { Events } from './pcui';
+import { Events } from '@playcanvas/observer';
 
 /**
  * Enables undo / redo of selection changes

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -14,12 +14,8 @@ module.exports = function (config) {
             'node_modules/chai/chai.js',
 
             'test/lib/schema.js',
-            'dist/api.js',
-            {
-                pattern: 'node_modules/@playcanvas/pcui/pcui-binding.mjs',
-                type: 'module',
-                nocache : true
-            },
+            'node_modules/@playcanvas/observer/index.js',
+            'dist/index.js',
 
             {
                 pattern: 'test/setup.js',

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,5 +1,3 @@
-import { Observer, ObserverList, ObserverHistory } from '/base/node_modules/@playcanvas/pcui/pcui-binding.mjs';
-
 // move chai methods to window
 for (const member in chai) {
     window[member] = chai[member];
@@ -7,9 +5,6 @@ for (const member in chai) {
 
 // create pcui namespace
 window.pcui = {};
-window.Observer = Observer;
-window.ObserverList = ObserverList;
-window.ObserverHistory = ObserverHistory;
 
 // create pc namespace
 window.pc = {};


### PR DESCRIPTION
This PR uses @playcanvas/observer for dependencies to observer etc.
It also adds a module build apart from the umd build.
In addition it updates to @babel/eslint-parser because babel-eslint is deprecated.