### PR TITLE
Enabled deleting entities in the backend

### DIFF
--- a/src/entities.js
+++ b/src/entities.js
@@ -238,11 +238,11 @@ class Entities extends Events {
      *
      * @example
      * ```javascript
-     * editor.entities.delete([entity1, entity2]);
+     * await editor.entities.delete([entity1, entity2]);
      * ```
      */
-    delete(entities, options = {}) {
-        deleteEntities(entities, options);
+    async delete(entities, options = {}) {
+        await deleteEntities(entities, options);
     }
 
     /**
@@ -275,6 +275,8 @@ class Entities extends Events {
      * @param {boolean} [options.select] - Whether to select the new entities. Defaults to false.
      * @param {boolean} [options.rename] - Whether to rename the duplicated entities. Defaults to false.
      * @returns {Promise<Entity[]>} The duplicated entities
+     * @example
+     * const duplicated = await editor.entities.duplicate(entities);
      */
     async duplicate(entities, options = {}) {
         const result = await duplicateEntities(entities, options);

--- a/src/entities/duplicate.js
+++ b/src/entities/duplicate.js
@@ -302,7 +302,7 @@ async function duplicateEntities(entities, options) {
     let newEntities = [];
 
     // If we have a lot of entities duplicate in the backend
-    if (entities.length > USE_BACKEND_LIMIT && api.messenger) {
+    if (api.messenger && api.jobs && entities.length > USE_BACKEND_LIMIT) {
         newEntities = await duplicateInBackend(entities, options);
     } else {
         // remember previous selection

--- a/src/entity.js
+++ b/src/entity.js
@@ -402,6 +402,7 @@ class Entity extends Events {
      *
      * @param {object} options - Options
      * @param {boolean} options.history - Whether to record a history action. Defaults to true.
+     * @returns {Promise<void>} A promise
      * @example
      * ```javascript
      * editor.entities.root.findByName('door').delete();
@@ -409,7 +410,7 @@ class Entity extends Events {
      *
      */
     delete(options = {}) {
-        api.entities.delete([this], options);
+        return api.entities.delete([this], options);
     }
 
     /**

--- a/src/globals.js
+++ b/src/globals.js
@@ -96,6 +96,24 @@ class globals {
      * @category Internal
      */
     static hasLegacyScripts;
+
+    /**
+     * Alert function called when user confirmation is needed
+     * for an action. Defaults to the default browser popup but
+     * can be overriden to show your custom popup instead.
+     *
+     * @param {string} text - The confirm dialog text
+     * @param {object} options - Options for the popup
+     * @param {string} options.yesText - Text for 'yes' option
+     * @param {string} options.noText - Text for 'no' option
+     * @param {boolean} options.noDismiss - If true then user cannot dismiss the popup and will have to click yes or no
+     * @returns {Promise<boolean>} True if the user confirmed, false otherwise
+     */
+    static confirmFn(text, options = {}) {
+        return new Promise((resolve) => {
+            resolve(confirm(text)); // eslint-disable-line
+        });
+    }
 }
 
 export { globals };

--- a/test/api/test-entities.js
+++ b/test/api/test-entities.js
@@ -160,13 +160,13 @@ describe('api.Entities tests', function () {
         expect(e.children[0].children[0].get('name')).to.equal('subchild');
     });
 
-    it('delete removes entity', function () {
+    it('delete removes entity', async function () {
         const e = api.globals.entities.create();
-        api.globals.entities.delete([e]);
+        await api.globals.entities.delete([e]);
         expect(api.globals.entities.get(e.get('resource_id'))).to.equal(null);
     });
 
-    it('delete removes children', function () {
+    it('delete removes children', async function () {
         const e = api.globals.entities.create({
             name: 'parent',
             children: [{
@@ -176,13 +176,13 @@ describe('api.Entities tests', function () {
 
         const c = e.children[0];
 
-        api.globals.entities.delete([e]);
+        await api.globals.entities.delete([e]);
 
         expect(api.globals.entities.get(c.get('resource_id'))).to.equal(null);
         expect(api.globals.entities.get(e.get('resource_id'))).to.equal(null);
     });
 
-    it('delete works when children are passed along with parents', function () {
+    it('delete works when children are passed along with parents', async function () {
         const e = api.globals.entities.create({
             name: 'parent',
             children: [{
@@ -192,13 +192,13 @@ describe('api.Entities tests', function () {
 
         const c = e.children[0];
 
-        api.globals.entities.delete([c, e]);
+        await api.globals.entities.delete([c, e]);
 
         expect(api.globals.entities.get(c.get('resource_id'))).to.equal(null);
         expect(api.globals.entities.get(e.get('resource_id'))).to.equal(null);
     });
 
-    it('undo delete brings back entities with same data as before', function () {
+    it('undo delete brings back entities with same data as before', async function () {
         api.globals.history = new api.History();
 
         const e = api.globals.entities.create({
@@ -213,7 +213,7 @@ describe('api.Entities tests', function () {
         const eJson = e.json();
         const cJson = c.json();
 
-        api.globals.entities.delete([e]);
+        await api.globals.entities.delete([e]);
 
         api.globals.history.undo();
 
@@ -227,7 +227,7 @@ describe('api.Entities tests', function () {
         expect(api.globals.entities.get(c.get('resource_id')).json()).to.deep.equal(cJson);
     });
 
-    it('redo delete deletes entities', function () {
+    it('redo delete deletes entities', async function () {
         api.globals.history = new api.History();
 
         const e = api.globals.entities.create({
@@ -239,7 +239,7 @@ describe('api.Entities tests', function () {
 
         const c = e.children[0];
 
-        api.globals.entities.delete([e]);
+        await api.globals.entities.delete([e]);
 
         api.globals.history.undo();
         api.globals.history.redo();
@@ -248,7 +248,7 @@ describe('api.Entities tests', function () {
         expect(api.globals.entities.get(c.get('resource_id'))).to.equal(null);
     });
 
-    it('delete removes from selection', function () {
+    it('delete removes from selection', async function () {
         api.globals.history = new api.History();
         api.globals.selection = new api.Selection();
 
@@ -257,7 +257,7 @@ describe('api.Entities tests', function () {
         });
 
         expect(api.globals.selection.items).to.deep.equal([e]);
-        api.globals.entities.delete([e]);
+        await api.globals.entities.delete([e]);
         expect(api.globals.selection.items).to.deep.equal([]);
 
         // check undo brings back selection
@@ -265,7 +265,7 @@ describe('api.Entities tests', function () {
         expect(api.globals.selection.items[0].get('resource_id')).to.equal(e.get('resource_id'));
     });
 
-    it('delete removes entity references', function () {
+    it('delete removes entity references', async function () {
         api.globals.schema = new api.Schema(schema);
         api.globals.history = new api.History();
         api.globals.assets = new api.Assets();
@@ -321,7 +321,7 @@ describe('api.Entities tests', function () {
             expect(e.get('components.script.scripts.test.attributes.jsonArray.0.entityArray')).to.deep.equal([reference, reference]);
         });
 
-        api.globals.entities.delete([c1]);
+        await api.globals.entities.delete([c1]);
 
         [root, c1, c2, c3].forEach(e => {
             expect(e.get('components.testcomponent.entityRef')).to.equal(null);


### PR DESCRIPTION
This PR changes deleting entities, to be performed in the backend when there are a lot of entities.

It also introduces a `confirmFn` function which is used to show confirmation popups. That defaults to the browser confirm function but the Editor will override it to show it's custom confirmation dialogs.