### PR TITLE
Use XMLHttpRequest for asset uploads

### DIFF
--- a/src/assets/upload.js
+++ b/src/assets/upload.js
@@ -80,9 +80,10 @@ function appendCreateFields(form, data) {
  *
  * @param {object} data - The data
  * @param {object} settings - Import settings
+ * @param {Function} onProgress - Progress function
  * @returns {object} The JSON response from the server
  */
-async function uploadFile(data, settings = {}) {
+async function uploadFile(data, settings = {}, onProgress = null) {
     let method;
     let url;
 
@@ -96,17 +97,81 @@ async function uploadFile(data, settings = {}) {
         url = '/api/assets';
     }
 
-    const response = await fetch(url, {
-        body: form,
-        method: method
+    const response = await new Promise(resolve => {
+        let progress;
+
+        function onProgressUpdate(value) {
+            if (progress !== value) {
+                progress = value;
+                if (onProgress) {
+                    onProgress(progress);
+                }
+            }
+        }
+
+        function onError(status, err) {
+            resolve({
+                ok: false,
+                status: status,
+                error: err
+            });
+        }
+
+        const xhr = new XMLHttpRequest();
+        xhr.withCredentials = true;
+        xhr.addEventListener('load', () => {
+            onProgressUpdate(1.0);
+
+            if (xhr.status === 200 || xhr.status === 201) {
+                resolve({
+                    ok: true,
+                    status: xhr.status,
+                    json: JSON.parse(xhr.responseText)
+                });
+            } else {
+                try {
+                    const json = JSON.parse(xhr.responseText);
+                    let msg = json.message;
+                    if (! msg) {
+                        msg = json.error || (json.response && json.response.error);
+                    }
+
+                    if (! msg) {
+                        msg = xhr.responseText;
+                    }
+
+                    onError(xhr.status, msg);
+                } catch (ex) {
+                    onError(xhr.status, ex);
+                }
+            }
+        });
+
+        xhr.upload.addEventListener('progress', evt => {
+            if (!evt.lengthComputable) return;
+
+            onProgressUpdate(evt.loaded / evt.total);
+        });
+
+        xhr.addEventListener('error', evt => {
+            onError(xhr.status, evt);
+        });
+
+        xhr.addEventListener('abort', evt => {
+            onError(xhr.status, evt);
+        });
+
+        onProgressUpdate(0);
+
+        xhr.open(method, url, true);
+        xhr.send(form);
     });
 
     if (!response.ok) {
-        throw new Error(response.status + ': ' + response.statusText);
+        throw new Error(`${response.status}${response.error ? ': ' + response.error : ''}`);
     }
 
-    const json = await response.json();
-    return json;
+    return response.json;
 }
 
 export { uploadFile };

--- a/src/assets/upload.js
+++ b/src/assets/upload.js
@@ -1,7 +1,7 @@
 import { globals as api } from '../globals';
 
 function getSetting(settings, name, defaultValue) {
-    return settings[name] !== undefined ? settings[name] : defaultValue;
+    return settings && settings[name] !== undefined ? settings[name] : defaultValue;
 }
 
 function createFormData(data, settings) {
@@ -83,7 +83,7 @@ function appendCreateFields(form, data) {
  * @param {Function} onProgress - Progress function
  * @returns {object} The JSON response from the server
  */
-async function uploadFile(data, settings = {}, onProgress = null) {
+async function uploadFile(data, settings = null, onProgress = null) {
     let method;
     let url;
 

--- a/test/api/test-assets.js
+++ b/test/api/test-assets.js
@@ -194,7 +194,11 @@ ${className}.prototype.update = function(dt) {
     });
 
     it('creates anim state graph', function () {
-        sandbox.stub(window, 'fetch');
+        const xhr = sandbox.useFakeXMLHttpRequest();
+        const requests = [];
+        xhr.onCreate = (fake) => {
+            requests.push(fake);
+        };
 
         api.globals.branchId = 'branch';
         api.globals.projectId = 1;
@@ -206,9 +210,9 @@ ${className}.prototype.update = function(dt) {
             folder: folder
         });
 
-        const fetchArgs = window.fetch.getCall(0).args;
-        expect(fetchArgs[1].body instanceof FormData).to.equal(true);
-        const data = fetchArgs[1].body;
+        expect(requests.length).to.equal(1);
+        expect(requests[0].requestBody instanceof FormData).to.equal(true);
+        const data = requests[0].requestBody;
         expect(data.get('branchId')).to.equal('branch');
         expect(data.get('projectId')).to.equal('1');
         expect(data.get('type')).to.equal('animstategraph');
@@ -221,7 +225,11 @@ ${className}.prototype.update = function(dt) {
     });
 
     it('creates bundle', function () {
-        sandbox.stub(window, 'fetch');
+        const xhr = sandbox.useFakeXMLHttpRequest();
+        const requests = [];
+        xhr.onCreate = (fake) => {
+            requests.push(fake);
+        };
 
         api.globals.branchId = 'branch';
         api.globals.projectId = 1;
@@ -235,9 +243,9 @@ ${className}.prototype.update = function(dt) {
             folder: folder
         });
 
-        const fetchArgs = window.fetch.getCall(0).args;
-        expect(fetchArgs[1].body instanceof FormData).to.equal(true);
-        const data = fetchArgs[1].body;
+        expect(requests.length).to.equal(1);
+        expect(requests[0].requestBody instanceof FormData).to.equal(true);
+        const data = requests[0].requestBody;
         expect(data.get('branchId')).to.equal('branch');
         expect(data.get('projectId')).to.equal('1');
         expect(data.get('type')).to.equal('bundle');
@@ -250,7 +258,11 @@ ${className}.prototype.update = function(dt) {
     });
 
     it('creates css asset', async function () {
-        sandbox.stub(window, 'fetch');
+        const xhr = sandbox.useFakeXMLHttpRequest();
+        const requests = [];
+        xhr.onCreate = (fake) => {
+            requests.push(fake);
+        };
 
         api.globals.branchId = 'branch';
         api.globals.projectId = 1;
@@ -262,9 +274,9 @@ ${className}.prototype.update = function(dt) {
             folder: folder
         });
 
-        const fetchArgs = window.fetch.getCall(0).args;
-        expect(fetchArgs[1].body instanceof FormData).to.equal(true);
-        const data = fetchArgs[1].body;
+        expect(requests.length).to.equal(1);
+        expect(requests[0].requestBody instanceof FormData).to.equal(true);
+        const data = requests[0].requestBody;
         expect(data.get('branchId')).to.equal('branch');
         expect(data.get('projectId')).to.equal('1');
         expect(data.get('filename')).to.equal('asset.css');
@@ -277,7 +289,11 @@ ${className}.prototype.update = function(dt) {
     });
 
     it('creates cubemap asset', function () {
-        sandbox.stub(window, 'fetch');
+        const xhr = sandbox.useFakeXMLHttpRequest();
+        const requests = [];
+        xhr.onCreate = (fake) => {
+            requests.push(fake);
+        };
 
         api.globals.branchId = 'branch';
         api.globals.projectId = 1;
@@ -295,9 +311,9 @@ ${className}.prototype.update = function(dt) {
             folder: folder
         });
 
-        const fetchArgs = window.fetch.getCall(0).args;
-        expect(fetchArgs[1].body instanceof FormData).to.equal(true);
-        const data = fetchArgs[1].body;
+        expect(requests.length).to.equal(1);
+        expect(requests[0].requestBody instanceof FormData).to.equal(true);
+        const data = requests[0].requestBody;
         expect(data.get('branchId')).to.equal('branch');
         expect(data.get('projectId')).to.equal('1');
         expect(data.get('type')).to.equal('cubemap');
@@ -314,7 +330,11 @@ ${className}.prototype.update = function(dt) {
     });
 
     it('creates folder asset', function () {
-        sandbox.stub(window, 'fetch');
+        const xhr = sandbox.useFakeXMLHttpRequest();
+        const requests = [];
+        xhr.onCreate = (fake) => {
+            requests.push(fake);
+        };
 
         api.globals.branchId = 'branch';
         api.globals.projectId = 1;
@@ -331,9 +351,9 @@ ${className}.prototype.update = function(dt) {
             folder: folder
         });
 
-        const fetchArgs = window.fetch.getCall(0).args;
-        expect(fetchArgs[1].body instanceof FormData).to.equal(true);
-        const data = fetchArgs[1].body;
+        expect(requests.length).to.equal(1);
+        expect(requests[0].requestBody instanceof FormData).to.equal(true);
+        const data = requests[0].requestBody;
         expect(data.get('branchId')).to.equal('branch');
         expect(data.get('projectId')).to.equal('1');
         expect(data.get('type')).to.equal('folder');
@@ -343,7 +363,11 @@ ${className}.prototype.update = function(dt) {
     });
 
     it('creates html asset', async function () {
-        sandbox.stub(window, 'fetch');
+        const xhr = sandbox.useFakeXMLHttpRequest();
+        const requests = [];
+        xhr.onCreate = (fake) => {
+            requests.push(fake);
+        };
 
         api.globals.branchId = 'branch';
         api.globals.projectId = 1;
@@ -355,9 +379,9 @@ ${className}.prototype.update = function(dt) {
             folder: folder
         });
 
-        const fetchArgs = window.fetch.getCall(0).args;
-        expect(fetchArgs[1].body instanceof FormData).to.equal(true);
-        const data = fetchArgs[1].body;
+        expect(requests.length).to.equal(1);
+        expect(requests[0].requestBody instanceof FormData).to.equal(true);
+        const data = requests[0].requestBody;
         expect(data.get('branchId')).to.equal('branch');
         expect(data.get('projectId')).to.equal('1');
         expect(data.get('filename')).to.equal('asset.html');
@@ -370,7 +394,11 @@ ${className}.prototype.update = function(dt) {
     });
 
     it('creates json asset', async function () {
-        sandbox.stub(window, 'fetch');
+        const xhr = sandbox.useFakeXMLHttpRequest();
+        const requests = [];
+        xhr.onCreate = (fake) => {
+            requests.push(fake);
+        };
 
         api.globals.branchId = 'branch';
         api.globals.projectId = 1;
@@ -382,9 +410,9 @@ ${className}.prototype.update = function(dt) {
             folder: folder
         });
 
-        const fetchArgs = window.fetch.getCall(0).args;
-        expect(fetchArgs[1].body instanceof FormData).to.equal(true);
-        const data = fetchArgs[1].body;
+        expect(requests.length).to.equal(1);
+        expect(requests[0].requestBody instanceof FormData).to.equal(true);
+        const data = requests[0].requestBody;
         expect(data.get('branchId')).to.equal('branch');
         expect(data.get('projectId')).to.equal('1');
         expect(data.get('filename')).to.equal('asset.json');
@@ -397,7 +425,11 @@ ${className}.prototype.update = function(dt) {
     });
 
     it('creates i18n asset', async function () {
-        sandbox.stub(window, 'fetch');
+        const xhr = sandbox.useFakeXMLHttpRequest();
+        const requests = [];
+        xhr.onCreate = (fake) => {
+            requests.push(fake);
+        };
 
         api.globals.branchId = 'branch';
         api.globals.projectId = 1;
@@ -408,9 +440,9 @@ ${className}.prototype.update = function(dt) {
             folder: folder
         });
 
-        const fetchArgs = window.fetch.getCall(0).args;
-        expect(fetchArgs[1].body instanceof FormData).to.equal(true);
-        const data = fetchArgs[1].body;
+        expect(requests.length).to.equal(1);
+        expect(requests[0].requestBody instanceof FormData).to.equal(true);
+        const data = requests[0].requestBody;
         expect(data.get('branchId')).to.equal('branch');
         expect(data.get('projectId')).to.equal('1');
         expect(data.get('filename')).to.equal('asset.json');
@@ -436,7 +468,11 @@ ${className}.prototype.update = function(dt) {
     });
 
     it('creates material asset', function () {
-        sandbox.stub(window, 'fetch');
+        const xhr = sandbox.useFakeXMLHttpRequest();
+        const requests = [];
+        xhr.onCreate = (fake) => {
+            requests.push(fake);
+        };
 
         api.globals.branchId = 'branch';
         api.globals.projectId = 1;
@@ -448,9 +484,9 @@ ${className}.prototype.update = function(dt) {
             folder: folder
         });
 
-        const fetchArgs = window.fetch.getCall(0).args;
-        expect(fetchArgs[1].body instanceof FormData).to.equal(true);
-        const data = fetchArgs[1].body;
+        expect(requests.length).to.equal(1);
+        expect(requests[0].requestBody instanceof FormData).to.equal(true);
+        const data = requests[0].requestBody;
         expect(data.get('branchId')).to.equal('branch');
         expect(data.get('projectId')).to.equal('1');
         expect(data.get('type')).to.equal('material');
@@ -463,7 +499,11 @@ ${className}.prototype.update = function(dt) {
     });
 
     it('creates shader asset', async function () {
-        sandbox.stub(window, 'fetch');
+        const xhr = sandbox.useFakeXMLHttpRequest();
+        const requests = [];
+        xhr.onCreate = (fake) => {
+            requests.push(fake);
+        };
 
         api.globals.branchId = 'branch';
         api.globals.projectId = 1;
@@ -475,9 +515,9 @@ ${className}.prototype.update = function(dt) {
             folder: folder
         });
 
-        const fetchArgs = window.fetch.getCall(0).args;
-        expect(fetchArgs[1].body instanceof FormData).to.equal(true);
-        const data = fetchArgs[1].body;
+        expect(requests.length).to.equal(1);
+        expect(requests[0].requestBody instanceof FormData).to.equal(true);
+        const data = requests[0].requestBody;
         expect(data.get('branchId')).to.equal('branch');
         expect(data.get('projectId')).to.equal('1');
         expect(data.get('filename')).to.equal('asset.glsl');
@@ -490,7 +530,11 @@ ${className}.prototype.update = function(dt) {
     });
 
     it('creates sprite asset', function () {
-        sandbox.stub(window, 'fetch');
+        const xhr = sandbox.useFakeXMLHttpRequest();
+        const requests = [];
+        xhr.onCreate = (fake) => {
+            requests.push(fake);
+        };
 
         api.globals.branchId = 'branch';
         api.globals.projectId = 1;
@@ -503,9 +547,9 @@ ${className}.prototype.update = function(dt) {
             folder: folder
         });
 
-        const fetchArgs = window.fetch.getCall(0).args;
-        expect(fetchArgs[1].body instanceof FormData).to.equal(true);
-        const data = fetchArgs[1].body;
+        expect(requests.length).to.equal(1);
+        expect(requests[0].requestBody instanceof FormData).to.equal(true);
+        const data = requests[0].requestBody;
         expect(data.get('branchId')).to.equal('branch');
         expect(data.get('projectId')).to.equal('1');
         expect(data.get('type')).to.equal('sprite');
@@ -521,7 +565,11 @@ ${className}.prototype.update = function(dt) {
     });
 
     it('creates text asset', async function () {
-        sandbox.stub(window, 'fetch');
+        const xhr = sandbox.useFakeXMLHttpRequest();
+        const requests = [];
+        xhr.onCreate = (fake) => {
+            requests.push(fake);
+        };
 
         api.globals.branchId = 'branch';
         api.globals.projectId = 1;
@@ -533,9 +581,9 @@ ${className}.prototype.update = function(dt) {
             folder: folder
         });
 
-        const fetchArgs = window.fetch.getCall(0).args;
-        expect(fetchArgs[1].body instanceof FormData).to.equal(true);
-        const data = fetchArgs[1].body;
+        expect(requests.length).to.equal(1);
+        expect(requests[0].requestBody instanceof FormData).to.equal(true);
+        const data = requests[0].requestBody;
         expect(data.get('branchId')).to.equal('branch');
         expect(data.get('projectId')).to.equal('1');
         expect(data.get('filename')).to.equal('asset.txt');
@@ -548,7 +596,11 @@ ${className}.prototype.update = function(dt) {
     });
 
     it('creates template asset', function () {
-        sandbox.stub(window, 'fetch');
+        const xhr = sandbox.useFakeXMLHttpRequest();
+        const requests = [];
+        xhr.onCreate = (fake) => {
+            requests.push(fake);
+        };
 
         api.globals.schema = new api.Schema(schema);
         api.globals.entities = new api.Entities();
@@ -573,9 +625,9 @@ ${className}.prototype.update = function(dt) {
             folder: folder
         });
 
-        const fetchArgs = window.fetch.getCall(0).args;
-        expect(fetchArgs[1].body instanceof FormData).to.equal(true);
-        const data = fetchArgs[1].body;
+        expect(requests.length).to.equal(1);
+        expect(requests[0].requestBody instanceof FormData).to.equal(true);
+        const data = requests[0].requestBody;
         expect(data.get('branchId')).to.equal('branch');
         expect(data.get('projectId')).to.equal('1');
         expect(data.get('type')).to.equal('template');
@@ -597,7 +649,11 @@ ${className}.prototype.update = function(dt) {
     });
 
     it('template asset remaps entity references', function () {
-        sandbox.stub(window, 'fetch');
+        const xhr = sandbox.useFakeXMLHttpRequest();
+        const requests = [];
+        xhr.onCreate = (fake) => {
+            requests.push(fake);
+        };
 
         api.globals.schema = new api.Schema(schema);
         api.globals.entities = new api.Entities();
@@ -620,9 +676,9 @@ ${className}.prototype.update = function(dt) {
             entity: root
         });
 
-        const fetchArgs = window.fetch.getCall(0).args;
-        expect(fetchArgs[1].body instanceof FormData).to.equal(true);
-        const data = fetchArgs[1].body;
+        expect(requests.length).to.equal(1);
+        expect(requests[0].requestBody instanceof FormData).to.equal(true);
+        const data = requests[0].requestBody;
 
         const expected = { entities: {} };
 
@@ -639,7 +695,11 @@ ${className}.prototype.update = function(dt) {
     });
 
     it('template asset remaps template_ent_ids', function () {
-        sandbox.stub(window, 'fetch');
+        const xhr = sandbox.useFakeXMLHttpRequest();
+        const requests = [];
+        xhr.onCreate = (fake) => {
+            requests.push(fake);
+        };
 
         api.globals.schema = new api.Schema(schema);
         api.globals.entities = new api.Entities();
@@ -687,9 +747,9 @@ ${className}.prototype.update = function(dt) {
             entity: root
         });
 
-        const fetchArgs = window.fetch.getCall(0).args;
-        expect(fetchArgs[1].body instanceof FormData).to.equal(true);
-        const data = fetchArgs[1].body;
+        expect(requests.length).to.equal(1);
+        expect(requests[0].requestBody instanceof FormData).to.equal(true);
+        const data = requests[0].requestBody;
 
         const expected = { entities: {} };
 
@@ -720,7 +780,11 @@ ${className}.prototype.update = function(dt) {
     });
 
     it('creates script asset', async function () {
-        sandbox.stub(window, 'fetch');
+        const xhr = sandbox.useFakeXMLHttpRequest();
+        const requests = [];
+        xhr.onCreate = (fake) => {
+            requests.push(fake);
+        };
 
         api.globals.branchId = 'branch';
         api.globals.projectId = 1;
@@ -731,9 +795,9 @@ ${className}.prototype.update = function(dt) {
             folder: folder
         });
 
-        const fetchArgs = window.fetch.getCall(0).args;
-        expect(fetchArgs[1].body instanceof FormData).to.equal(true);
-        const data = fetchArgs[1].body;
+        expect(requests.length).to.equal(1);
+        expect(requests[0].requestBody instanceof FormData).to.equal(true);
+        const data = requests[0].requestBody;
         expect(data.get('branchId')).to.equal('branch');
         expect(data.get('projectId')).to.equal('1');
         expect(data.get('filename')).to.equal('name.js');
@@ -752,7 +816,11 @@ ${className}.prototype.update = function(dt) {
     });
 
     it('creates valid script names', async function () {
-        sandbox.stub(window, 'fetch');
+        const xhr = sandbox.useFakeXMLHttpRequest();
+        const requests = [];
+        xhr.onCreate = (fake) => {
+            requests.push(fake);
+        };
 
         // row format is desired name, expected class name, expected script name
         const names = [
@@ -767,9 +835,9 @@ ${className}.prototype.update = function(dt) {
                 name: names[i]
             });
 
-            const fetchArgs = window.fetch.getCall(i / 3).args;
-            expect(fetchArgs[1].body instanceof FormData).to.equal(true);
-            const data = fetchArgs[1].body;
+            const request = requests[i / 3];
+            expect(request.requestBody instanceof FormData).to.equal(true);
+            const data = request.requestBody;
             expect(await data.get('file').text()).to.equal(boilerplate(names[i + 1], names[i + 2])); // eslint-disable-line no-await-in-loop
         }
 


### PR DESCRIPTION
This PR uses XMLHttpRequest for uploading assets because the fetch API does not have a proper progress reporting mechanism yet.

It also adds default progress reporting callbacks in the assets API to hook up custom handling from the Editor (to show progress bars, errors etc).