### PR TITLE
Added selection.item property

### DIFF
--- a/src/selection.js
+++ b/src/selection.js
@@ -314,6 +314,15 @@ class Selection extends Events {
     }
 
     /**
+     * Gets the first selected item. Short for this.items[0].
+     *
+     * @type {any[]}
+     */
+    get item() {
+        return this._items[0];
+    }
+
+    /**
      * Enables / disables the selection methods
      *
      * @type {boolean}

--- a/test/api/test-selection.js
+++ b/test/api/test-selection.js
@@ -17,6 +17,7 @@ describe('api.Selection tests', function () {
         const item = new api.Entity();
         api.globals.selection.add(item);
         expect(api.globals.selection.items).to.deep.equal([item]);
+        expect(api.globals.selection.item).to.equal(item);
         expect(api.globals.selection.emit.calledOnceWith('add', item)).to.equal(true);
         api.globals.selection.emit.resetHistory();
         setTimeout(() => {


### PR DESCRIPTION
Often you just have one item selected and you want to quickly access it. This PR adds `selection.item` which is a shorthand for `selection.items[0]`.