### PR TITLE
Asset replace

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,8 @@
 PlayCanvas Editor API / [Exports](modules.md)
 
 # Overview
-This is the PlayCanvas Editor API. You can find API documentation [here](modules.md).
+
+This is the PlayCanvas Editor API. You can find API documentation [here](docs/modules.md).
 
 # Installing
 Run:

--- a/docs/classes/Asset.md
+++ b/docs/classes/Asset.md
@@ -27,6 +27,7 @@ Represents an Asset. For a list of Asset properties see [here](AssetProperties.m
 - [loadAndSubscribe](Asset.md#loadandsubscribe)
 - [delete](Asset.md#delete)
 - [instantiateTemplate](Asset.md#instantiatetemplate)
+- [replace](Asset.md#replace)
 
 ### Constructors
 
@@ -59,7 +60,7 @@ The file URL
 
 #### Defined in
 
-[src/asset.js:294](https://github.com/playcanvas/editor-api/blob/43e144d/src/asset.js#L294)
+[src/asset.js:307](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L307)
 
 ___
 
@@ -83,7 +84,7 @@ True if path exists
 
 #### Defined in
 
-[src/asset.js:110](https://github.com/playcanvas/editor-api/blob/43e144d/src/asset.js#L110)
+[src/asset.js:111](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L111)
 
 ___
 
@@ -107,7 +108,7 @@ The value
 
 #### Defined in
 
-[src/asset.js:120](https://github.com/playcanvas/editor-api/blob/43e144d/src/asset.js#L120)
+[src/asset.js:121](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L121)
 
 ___
 
@@ -132,7 +133,7 @@ Whether the value was set
 
 #### Defined in
 
-[src/asset.js:131](https://github.com/playcanvas/editor-api/blob/43e144d/src/asset.js#L131)
+[src/asset.js:132](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L132)
 
 ___
 
@@ -156,7 +157,7 @@ Whether the value was unset
 
 #### Defined in
 
-[src/asset.js:141](https://github.com/playcanvas/editor-api/blob/43e144d/src/asset.js#L141)
+[src/asset.js:142](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L142)
 
 ___
 
@@ -182,7 +183,7 @@ Whether the value was inserted
 
 #### Defined in
 
-[src/asset.js:153](https://github.com/playcanvas/editor-api/blob/43e144d/src/asset.js#L153)
+[src/asset.js:154](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L154)
 
 ___
 
@@ -207,7 +208,7 @@ Whether the value was removed
 
 #### Defined in
 
-[src/asset.js:164](https://github.com/playcanvas/editor-api/blob/43e144d/src/asset.js#L164)
+[src/asset.js:165](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L165)
 
 ___
 
@@ -225,7 +226,7 @@ Returns JSON representation of entity data
 
 #### Defined in
 
-[src/asset.js:173](https://github.com/playcanvas/editor-api/blob/43e144d/src/asset.js#L173)
+[src/asset.js:174](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L174)
 
 ___
 
@@ -243,7 +244,7 @@ The asset
 
 #### Defined in
 
-[src/asset.js:182](https://github.com/playcanvas/editor-api/blob/43e144d/src/asset.js#L182)
+[src/asset.js:183](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L183)
 
 ___
 
@@ -259,7 +260,7 @@ Loads asset from the server without subscribing to realtime changes.
 
 #### Defined in
 
-[src/asset.js:189](https://github.com/playcanvas/editor-api/blob/43e144d/src/asset.js#L189)
+[src/asset.js:190](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L190)
 
 ___
 
@@ -275,7 +276,7 @@ Loads the asset's data from sharedb and subscribes to changes
 
 #### Defined in
 
-[src/asset.js:214](https://github.com/playcanvas/editor-api/blob/43e144d/src/asset.js#L214)
+[src/asset.js:215](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L215)
 
 ___
 
@@ -291,7 +292,7 @@ Deletes this asset
 
 #### Defined in
 
-[src/asset.js:257](https://github.com/playcanvas/editor-api/blob/43e144d/src/asset.js#L257)
+[src/asset.js:258](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L258)
 
 ___
 
@@ -321,7 +322,32 @@ The new entity.
 
 #### Defined in
 
-[src/asset.js:273](https://github.com/playcanvas/editor-api/blob/43e144d/src/asset.js#L273)
+[src/asset.js:274](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L274)
+
+___
+
+### replace
+
+▸ **replace**(`asset`, `options?`): `void`
+
+Replaces any references to this asset with
+references to the new asset specified.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `asset` | [`Asset`](Asset.md) | The new asset. |
+| `options` | `Object` | Options. |
+| `options.history` | `boolean` | Whether to record a history action. |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[src/asset.js:287](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L287)
 
 ## Constructors
 
@@ -343,7 +369,7 @@ Events.constructor
 
 #### Defined in
 
-[src/asset.js:15](https://github.com/playcanvas/editor-api/blob/43e144d/src/asset.js#L15)
+[src/asset.js:16](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L16)
 
 ## Accessors
 
@@ -359,4 +385,4 @@ Gets observer history for this assset
 
 #### Defined in
 
-[src/asset.js:283](https://github.com/playcanvas/editor-api/blob/43e144d/src/asset.js#L283)
+[src/asset.js:296](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L296)

--- a/docs/classes/AssetProperties.md
+++ b/docs/classes/AssetProperties.md
@@ -43,7 +43,7 @@ These are the properties that you can access on an [Asset](Asset.md):
 
 | Path | Type | Description | Default Value | 
 | :------ | :------ | :------ | :------ |
-| `data.layers` | `object` | A set of AnimStateGraph layers. | `{"0":{"name":"Base","states":[0,1,2,3],"transitions":[0]}}`| 
+| `data.layers` | `object` | A set of AnimStateGraph layers. | `{"0":{"name":"Base","states":[0,1,2,3],"transitions":[0],"blendType":"OVERWRITE","weight":1}}`| 
 | `data.layers.*.blendType` | `string` | Defines the way in which this layer should blend with previous layers. Can be: `pc.ANIM_LAYER_OVERWRITE`, `pc.ANIM_LAYER_ADDITIVE`. |  | 
 | `data.layers.*.name` | `string` | The name of the AnimStateGraph layer. |  | 
 | `data.layers.*.states` | `Array<number>` | The id's of the states that this layer contains. |  | 

--- a/docs/classes/Assets.md
+++ b/docs/classes/Assets.md
@@ -78,7 +78,7 @@ Events.constructor
 
 #### Defined in
 
-[src/assets.js:62](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L62)
+[src/assets.js:62](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L62)
 
 ## Public Methods
 
@@ -102,7 +102,7 @@ The asset
 
 #### Defined in
 
-[src/assets.js:154](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L154)
+[src/assets.js:154](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L154)
 
 ___
 
@@ -126,7 +126,7 @@ The asset
 
 #### Defined in
 
-[src/assets.js:165](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L165)
+[src/assets.js:165](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L165)
 
 ___
 
@@ -144,7 +144,7 @@ The assets
 
 #### Defined in
 
-[src/assets.js:175](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L175)
+[src/assets.js:175](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L175)
 
 ___
 
@@ -168,7 +168,7 @@ The assets
 
 #### Defined in
 
-[src/assets.js:186](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L186)
+[src/assets.js:186](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L186)
 
 ___
 
@@ -192,7 +192,7 @@ The assets
 
 #### Defined in
 
-[src/assets.js:313](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L313)
+[src/assets.js:313](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L313)
 
 ___
 
@@ -216,7 +216,7 @@ The asset
 
 #### Defined in
 
-[src/assets.js:325](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L325)
+[src/assets.js:325](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L325)
 
 ___
 
@@ -240,7 +240,7 @@ The script asset
 
 #### Defined in
 
-[src/assets.js:442](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L442)
+[src/assets.js:442](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L442)
 
 ___
 
@@ -269,7 +269,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:506](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L506)
+[src/assets.js:506](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L506)
 
 ___
 
@@ -298,7 +298,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:527](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L527)
+[src/assets.js:527](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L527)
 
 ___
 
@@ -327,7 +327,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:550](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L550)
+[src/assets.js:550](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L550)
 
 ___
 
@@ -359,7 +359,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:576](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L576)
+[src/assets.js:576](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L576)
 
 ___
 
@@ -386,7 +386,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:606](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L606)
+[src/assets.js:606](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L606)
 
 ___
 
@@ -415,7 +415,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:625](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L625)
+[src/assets.js:625](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L625)
 
 ___
 
@@ -444,7 +444,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:647](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L647)
+[src/assets.js:647](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L647)
 
 ___
 
@@ -473,7 +473,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:669](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L669)
+[src/assets.js:669](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L669)
 
 ___
 
@@ -502,7 +502,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:702](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L702)
+[src/assets.js:702](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L702)
 
 ___
 
@@ -529,7 +529,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:734](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L734)
+[src/assets.js:734](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L734)
 
 ___
 
@@ -558,7 +558,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:780](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L780)
+[src/assets.js:794](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L794)
 
 ___
 
@@ -590,7 +590,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:805](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L805)
+[src/assets.js:819](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L819)
 
 ___
 
@@ -619,7 +619,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:832](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L832)
+[src/assets.js:846](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L846)
 
 ___
 
@@ -648,7 +648,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:855](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L855)
+[src/assets.js:869](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L869)
 
 ___
 
@@ -670,7 +670,7 @@ Deletes specified assets
 
 #### Defined in
 
-[src/assets.js:881](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L881)
+[src/assets.js:895](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L895)
 
 ___
 
@@ -701,7 +701,7 @@ The new entities
 
 #### Defined in
 
-[src/assets.js:913](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L913)
+[src/assets.js:927](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L927)
 
 ___
 
@@ -725,7 +725,7 @@ Adds asset to the list
 
 #### Defined in
 
-[src/assets.js:220](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L220)
+[src/assets.js:220](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L220)
 
 ___
 
@@ -747,7 +747,7 @@ Removes asset from the list
 
 #### Defined in
 
-[src/assets.js:272](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L272)
+[src/assets.js:272](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L272)
 
 ___
 
@@ -763,7 +763,7 @@ Removes all assets from the list
 
 #### Defined in
 
-[src/assets.js:293](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L293)
+[src/assets.js:293](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L293)
 
 ___
 
@@ -780,7 +780,7 @@ subscribe to realtime changes.
 
 #### Defined in
 
-[src/assets.js:336](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L336)
+[src/assets.js:336](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L336)
 
 ___
 
@@ -797,7 +797,7 @@ and subscribes to changes.
 
 #### Defined in
 
-[src/assets.js:385](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L385)
+[src/assets.js:385](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L385)
 
 ## Accessors
 
@@ -813,7 +813,7 @@ Gets the default callback called when on asset upload succeeds.
 
 #### Defined in
 
-[src/assets.js:922](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L922)
+[src/assets.js:936](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L936)
 
 • `set` **defaultUploadCompletedCallback**(`value`): `void`
 
@@ -832,7 +832,7 @@ The function takes 2 arguments: the upload id, and the new asset.
 
 #### Defined in
 
-[src/assets.js:932](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L932)
+[src/assets.js:946](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L946)
 
 ___
 
@@ -848,7 +848,7 @@ Gets the default callback called when on asset upload progress.
 
 #### Defined in
 
-[src/assets.js:941](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L941)
+[src/assets.js:955](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L955)
 
 • `set` **defaultUploadProgressCallback**(`value`): `void`
 
@@ -867,7 +867,7 @@ The function takes 2 arguments: the upload id and the progress.
 
 #### Defined in
 
-[src/assets.js:951](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L951)
+[src/assets.js:965](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L965)
 
 ___
 
@@ -883,7 +883,7 @@ Gets the default callback called when on asset upload fails.
 
 #### Defined in
 
-[src/assets.js:960](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L960)
+[src/assets.js:974](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L974)
 
 • `set` **defaultUploadErrorCallback**(`value`): `void`
 
@@ -902,7 +902,7 @@ The function takes 2 arguments: the upload id, and the error.
 
 #### Defined in
 
-[src/assets.js:970](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L970)
+[src/assets.js:984](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L984)
 
 ___
 
@@ -918,14 +918,14 @@ Gets the callback which parses script assets.
 
 #### Defined in
 
-[src/assets.js:979](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L979)
+[src/assets.js:993](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L993)
 
 • `set` **parseScriptCallback**(`value`): `void`
 
 Sets the callback which parses script assets. When this
 callback is set, new script assets will be parsed after they
 are created. The function takes the asset as a parameter and returns
-a promise when it is done parsing.
+a promise with a list of script names when it is done parsing.
 
 #### Parameters
 
@@ -939,4 +939,4 @@ a promise when it is done parsing.
 
 #### Defined in
 
-[src/assets.js:991](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L991)
+[src/assets.js:1005](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L1005)

--- a/docs/classes/AssetsSchema.md
+++ b/docs/classes/AssetsSchema.md
@@ -13,6 +13,7 @@ Provides methods to access the Assets schema
 ### Methods
 
 - [getDefaultData](AssetsSchema.md#getdefaultdata)
+- [getFieldsOfType](AssetsSchema.md#getfieldsoftype)
 
 ## Internal Constructors
 
@@ -30,7 +31,7 @@ Provides methods to access the Assets schema
 
 #### Defined in
 
-[src/schema/assets.js:14](https://github.com/playcanvas/editor-api/blob/43e144d/src/schema/assets.js#L14)
+[src/schema/assets.js:14](https://github.com/playcanvas/editor-api/blob/a50e91b/src/schema/assets.js#L14)
 
 ## Methods
 
@@ -54,4 +55,34 @@ The default data
 
 #### Defined in
 
-[src/schema/assets.js:25](https://github.com/playcanvas/editor-api/blob/43e144d/src/schema/assets.js#L25)
+[src/schema/assets.js:25](https://github.com/playcanvas/editor-api/blob/a50e91b/src/schema/assets.js#L25)
+
+___
+
+### getFieldsOfType
+
+▸ **getFieldsOfType**(`assetType`, `type`): `string`[]
+
+Gets a list of fields of a particular type for an asset type
+
+**`example`**
+```javascript
+const materialAssetPaths = editor.schema.assets.getFieldsOfType('material', 'asset');
+```
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `assetType` | `string` | The type of the asset. |
+| `type` | `string` | The desired type |
+
+#### Returns
+
+`string`[]
+
+A list of fields
+
+#### Defined in
+
+[src/schema/assets.js:55](https://github.com/playcanvas/editor-api/blob/a50e91b/src/schema/assets.js#L55)

--- a/docs/classes/Clipboard.md
+++ b/docs/classes/Clipboard.md
@@ -32,7 +32,7 @@ Constructor
 
 #### Defined in
 
-[src/clipboard.js:15](https://github.com/playcanvas/editor-api/blob/43e144d/src/clipboard.js#L15)
+[src/clipboard.js:15](https://github.com/playcanvas/editor-api/blob/a50e91b/src/clipboard.js#L15)
 
 ## Accessors
 
@@ -48,7 +48,7 @@ Gets whether the clipboard is empty
 
 #### Defined in
 
-[src/clipboard.js:26](https://github.com/playcanvas/editor-api/blob/43e144d/src/clipboard.js#L26)
+[src/clipboard.js:26](https://github.com/playcanvas/editor-api/blob/a50e91b/src/clipboard.js#L26)
 
 ___
 
@@ -64,7 +64,7 @@ Gets the value stored in the clipboard.
 
 #### Defined in
 
-[src/clipboard.js:35](https://github.com/playcanvas/editor-api/blob/43e144d/src/clipboard.js#L35)
+[src/clipboard.js:35](https://github.com/playcanvas/editor-api/blob/a50e91b/src/clipboard.js#L35)
 
 • `set` **value**(`value`): `void`
 
@@ -82,4 +82,4 @@ Sets the value to be stored in the clipboard. Pass null to clear the value from 
 
 #### Defined in
 
-[src/clipboard.js:44](https://github.com/playcanvas/editor-api/blob/43e144d/src/clipboard.js#L44)
+[src/clipboard.js:44](https://github.com/playcanvas/editor-api/blob/a50e91b/src/clipboard.js#L44)

--- a/docs/classes/ComponentSchema.md
+++ b/docs/classes/ComponentSchema.md
@@ -34,7 +34,7 @@ Creates new instance of API
 
 #### Defined in
 
-[src/schema/components.js:15](https://github.com/playcanvas/editor-api/blob/43e144d/src/schema/components.js#L15)
+[src/schema/components.js:15](https://github.com/playcanvas/editor-api/blob/a50e91b/src/schema/components.js#L15)
 
 ## Methods
 
@@ -63,7 +63,7 @@ The default data
 
 #### Defined in
 
-[src/schema/components.js:43](https://github.com/playcanvas/editor-api/blob/43e144d/src/schema/components.js#L43)
+[src/schema/components.js:43](https://github.com/playcanvas/editor-api/blob/a50e91b/src/schema/components.js#L43)
 
 ___
 
@@ -93,7 +93,7 @@ A list of fields
 
 #### Defined in
 
-[src/schema/components.js:69](https://github.com/playcanvas/editor-api/blob/43e144d/src/schema/components.js#L69)
+[src/schema/components.js:69](https://github.com/playcanvas/editor-api/blob/a50e91b/src/schema/components.js#L69)
 
 ___
 
@@ -111,4 +111,4 @@ The components
 
 #### Defined in
 
-[src/schema/components.js:103](https://github.com/playcanvas/editor-api/blob/43e144d/src/schema/components.js#L103)
+[src/schema/components.js:103](https://github.com/playcanvas/editor-api/blob/a50e91b/src/schema/components.js#L103)

--- a/docs/classes/Entities.md
+++ b/docs/classes/Entities.md
@@ -54,7 +54,7 @@ Events.constructor
 
 #### Defined in
 
-[src/entities.js:48](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L48)
+[src/entities.js:48](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L48)
 
 ## Public Methods
 
@@ -83,7 +83,7 @@ The entity
 
 #### Defined in
 
-[src/entities.js:68](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L68)
+[src/entities.js:68](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L68)
 
 ___
 
@@ -107,7 +107,7 @@ The entities
 
 #### Defined in
 
-[src/entities.js:83](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L83)
+[src/entities.js:83](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L83)
 
 ___
 
@@ -147,7 +147,7 @@ The new entity
 
 #### Defined in
 
-[src/entities.js:251](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L251)
+[src/entities.js:251](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L251)
 
 ___
 
@@ -176,7 +176,7 @@ await editor.entities.delete([entity1, entity2]);
 
 #### Defined in
 
-[src/entities.js:267](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L267)
+[src/entities.js:267](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L267)
 
 ___
 
@@ -211,7 +211,7 @@ editor.entities.reparent([{
 
 #### Defined in
 
-[src/entities.js:288](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L288)
+[src/entities.js:288](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L288)
 
 ___
 
@@ -242,7 +242,7 @@ The duplicated entities
 
 #### Defined in
 
-[src/entities.js:304](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L304)
+[src/entities.js:304](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L304)
 
 ___
 
@@ -265,7 +265,7 @@ to paste these entities later on.
 
 #### Defined in
 
-[src/entities.js:316](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L316)
+[src/entities.js:316](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L316)
 
 ___
 
@@ -292,7 +292,7 @@ The new entities
 
 #### Defined in
 
-[src/entities.js:329](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L329)
+[src/entities.js:329](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L329)
 
 ___
 
@@ -320,7 +320,7 @@ callback when the entities are added.
 
 #### Defined in
 
-[src/entities.js:344](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L344)
+[src/entities.js:344](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L344)
 
 ___
 
@@ -350,7 +350,7 @@ A promise
 
 #### Defined in
 
-[src/entities.js:362](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L362)
+[src/entities.js:362](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L362)
 
 ___
 
@@ -376,7 +376,7 @@ a single history action.
 
 #### Defined in
 
-[src/entities.js:375](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L375)
+[src/entities.js:375](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L375)
 
 ___
 
@@ -400,7 +400,7 @@ Adds entity to list
 
 #### Defined in
 
-[src/entities.js:93](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L93)
+[src/entities.js:93](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L93)
 
 ___
 
@@ -422,7 +422,7 @@ Called when an entity is added from the server
 
 #### Defined in
 
-[src/entities.js:121](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L121)
+[src/entities.js:121](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L121)
 
 ___
 
@@ -445,7 +445,7 @@ Removes entity from the list
 
 #### Defined in
 
-[src/entities.js:136](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L136)
+[src/entities.js:136](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L136)
 
 ___
 
@@ -467,7 +467,7 @@ Called when an entity is removed from the server
 
 #### Defined in
 
-[src/entities.js:185](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L185)
+[src/entities.js:185](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L185)
 
 ___
 
@@ -483,4 +483,4 @@ Removes all entities from the list
 
 #### Defined in
 
-[src/entities.js:207](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L207)
+[src/entities.js:207](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L207)

--- a/docs/classes/Entity.md
+++ b/docs/classes/Entity.md
@@ -68,7 +68,7 @@ Events.constructor
 
 #### Defined in
 
-[src/entity.js:17](https://github.com/playcanvas/editor-api/blob/43e144d/src/entity.js#L17)
+[src/entity.js:17](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L17)
 
 ## Public Methods
 
@@ -97,7 +97,7 @@ True if path exists
 
 #### Defined in
 
-[src/entity.js:88](https://github.com/playcanvas/editor-api/blob/43e144d/src/entity.js#L88)
+[src/entity.js:88](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L88)
 
 ___
 
@@ -126,7 +126,7 @@ The value
 
 #### Defined in
 
-[src/entity.js:102](https://github.com/playcanvas/editor-api/blob/43e144d/src/entity.js#L102)
+[src/entity.js:102](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L102)
 
 ___
 
@@ -156,7 +156,7 @@ Whether the value was set
 
 #### Defined in
 
-[src/entity.js:117](https://github.com/playcanvas/editor-api/blob/43e144d/src/entity.js#L117)
+[src/entity.js:117](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L117)
 
 ___
 
@@ -185,7 +185,7 @@ Whether the value was unset
 
 #### Defined in
 
-[src/entity.js:131](https://github.com/playcanvas/editor-api/blob/43e144d/src/entity.js#L131)
+[src/entity.js:131](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L131)
 
 ___
 
@@ -216,7 +216,7 @@ Whether the value was inserted
 
 #### Defined in
 
-[src/entity.js:147](https://github.com/playcanvas/editor-api/blob/43e144d/src/entity.js#L147)
+[src/entity.js:147](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L147)
 
 ___
 
@@ -244,7 +244,7 @@ entity.removeValue('tags', 'a_tag');
 
 #### Defined in
 
-[src/entity.js:161](https://github.com/playcanvas/editor-api/blob/43e144d/src/entity.js#L161)
+[src/entity.js:161](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L161)
 
 ___
 
@@ -265,7 +265,7 @@ console.log(entity.json());
 
 #### Defined in
 
-[src/entity.js:173](https://github.com/playcanvas/editor-api/blob/43e144d/src/entity.js#L173)
+[src/entity.js:173](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L173)
 
 ___
 
@@ -289,7 +289,7 @@ console.log(data.children[0].name);
 
 #### Defined in
 
-[src/entity.js:188](https://github.com/playcanvas/editor-api/blob/43e144d/src/entity.js#L188)
+[src/entity.js:188](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L188)
 
 ___
 
@@ -313,7 +313,7 @@ True if it is
 
 #### Defined in
 
-[src/entity.js:204](https://github.com/playcanvas/editor-api/blob/43e144d/src/entity.js#L204)
+[src/entity.js:204](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L204)
 
 ___
 
@@ -342,7 +342,7 @@ The entity
 
 #### Defined in
 
-[src/entity.js:227](https://github.com/playcanvas/editor-api/blob/43e144d/src/entity.js#L227)
+[src/entity.js:227](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L227)
 
 ___
 
@@ -376,7 +376,7 @@ The entities
 
 #### Defined in
 
-[src/entity.js:262](https://github.com/playcanvas/editor-api/blob/43e144d/src/entity.js#L262)
+[src/entity.js:262](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L262)
 
 ___
 
@@ -405,7 +405,7 @@ The result
 
 #### Defined in
 
-[src/entity.js:301](https://github.com/playcanvas/editor-api/blob/43e144d/src/entity.js#L301)
+[src/entity.js:301](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L301)
 
 ___
 
@@ -435,7 +435,7 @@ editor.entities.root.depthFirst(entity => entities.push(entity));
 
 #### Defined in
 
-[src/entity.js:331](https://github.com/playcanvas/editor-api/blob/43e144d/src/entity.js#L331)
+[src/entity.js:331](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L331)
 
 ___
 
@@ -465,7 +465,7 @@ editor.entities.root.addComponent('model', {
 
 #### Defined in
 
-[src/entity.js:357](https://github.com/playcanvas/editor-api/blob/43e144d/src/entity.js#L357)
+[src/entity.js:357](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L357)
 
 ___
 
@@ -492,7 +492,7 @@ editor.entities.root.removeComponent('model');
 
 #### Defined in
 
-[src/entity.js:372](https://github.com/playcanvas/editor-api/blob/43e144d/src/entity.js#L372)
+[src/entity.js:372](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L372)
 
 ___
 
@@ -522,7 +522,7 @@ A promise
 
 #### Defined in
 
-[src/entity.js:453](https://github.com/playcanvas/editor-api/blob/43e144d/src/entity.js#L453)
+[src/entity.js:453](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L453)
 
 ___
 
@@ -556,7 +556,7 @@ door.reparent(greenHouse);
 
 #### Defined in
 
-[src/entity.js:473](https://github.com/playcanvas/editor-api/blob/43e144d/src/entity.js#L473)
+[src/entity.js:473](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L473)
 
 ___
 
@@ -583,7 +583,7 @@ The new entity
 
 #### Defined in
 
-[src/entity.js:490](https://github.com/playcanvas/editor-api/blob/43e144d/src/entity.js#L490)
+[src/entity.js:490](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L490)
 
 ___
 
@@ -601,7 +601,7 @@ The entity
 
 #### Defined in
 
-[src/entity.js:500](https://github.com/playcanvas/editor-api/blob/43e144d/src/entity.js#L500)
+[src/entity.js:500](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L500)
 
 ___
 
@@ -631,7 +631,7 @@ A promise
 
 #### Defined in
 
-[src/entity.js:518](https://github.com/playcanvas/editor-api/blob/43e144d/src/entity.js#L518)
+[src/entity.js:518](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L518)
 
 ___
 
@@ -655,7 +655,7 @@ Removes a script from the entity's script component.
 
 #### Defined in
 
-[src/entity.js:529](https://github.com/playcanvas/editor-api/blob/43e144d/src/entity.js#L529)
+[src/entity.js:529](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L529)
 
 ___
 
@@ -681,7 +681,7 @@ Whether the child was added
 
 #### Defined in
 
-[src/entity.js:383](https://github.com/playcanvas/editor-api/blob/43e144d/src/entity.js#L383)
+[src/entity.js:383](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L383)
 
 ___
 
@@ -706,7 +706,7 @@ Whether the child was added
 
 #### Defined in
 
-[src/entity.js:395](https://github.com/playcanvas/editor-api/blob/43e144d/src/entity.js#L395)
+[src/entity.js:395](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L395)
 
 ___
 
@@ -728,4 +728,4 @@ Removes entity from children
 
 #### Defined in
 
-[src/entity.js:419](https://github.com/playcanvas/editor-api/blob/43e144d/src/entity.js#L419)
+[src/entity.js:419](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L419)

--- a/docs/classes/EntityProperties.md
+++ b/docs/classes/EntityProperties.md
@@ -29,6 +29,10 @@ These are the properties that you can access on an [Entity](Entity.md):
 | `components.anim.animationAssets` | `object` | A dictionary that holds the animation assets used by this component. Each key is a string which represents a path to a particular state in the graph e.g. "LocomotionLayer:Walking". | `{}`| 
 | `components.anim.animationAssets.*.asset` | `number` | The `id` of the The animation asset. | `null`| 
 | `components.anim.enabled` | `boolean` | Whether the component is enabled. | `true`| 
+| `components.anim.masks` | `object` | The layer masks associated with this component. | `{}`| 
+| `components.anim.masks.*.mask` | `object` | A set of paths to bones in the current model that should be animated by the layer. | `{}`| 
+| `components.anim.masks.*.mask.*.children` | `boolean` | Whether the children of this bone should also be included in the mask. |  | 
+| `components.anim.masks.*.mask.*.value` | `boolean` | Whether this bone should also be included in the mask. |  | 
 | `components.anim.rootBone` | `string` | The `resource_id` of the entity that this anim component should use as the root of the animation hierarchy. | `null`| 
 | `components.anim.speed` | `number` | A multiplier for animation playback speed. 0 will freeze animation playback, and 1 represents the normal playback speed. | `1`| 
 

--- a/docs/classes/Guid.md
+++ b/docs/classes/Guid.md
@@ -31,7 +31,7 @@ A new GUID.
 
 #### Defined in
 
-[src/guid.js:13](https://github.com/playcanvas/editor-api/blob/43e144d/src/guid.js#L13)
+[src/guid.js:13](https://github.com/playcanvas/editor-api/blob/a50e91b/src/guid.js#L13)
 
 ## Constructors
 

--- a/docs/classes/History.md
+++ b/docs/classes/History.md
@@ -46,7 +46,7 @@ Events.constructor
 
 #### Defined in
 
-[src/history.js:21](https://github.com/playcanvas/editor-api/blob/43e144d/src/history.js#L21)
+[src/history.js:21](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L21)
 
 ## Methods
 
@@ -78,7 +78,7 @@ editor.history.add({
 
 #### Defined in
 
-[src/history.js:45](https://github.com/playcanvas/editor-api/blob/43e144d/src/history.js#L45)
+[src/history.js:45](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L45)
 
 ___
 
@@ -99,7 +99,7 @@ editor.history.undo();
 
 #### Defined in
 
-[src/history.js:57](https://github.com/playcanvas/editor-api/blob/43e144d/src/history.js#L57)
+[src/history.js:57](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L57)
 
 ___
 
@@ -120,7 +120,7 @@ editor.history.redo();
 
 #### Defined in
 
-[src/history.js:69](https://github.com/playcanvas/editor-api/blob/43e144d/src/history.js#L69)
+[src/history.js:69](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L69)
 
 ___
 
@@ -141,7 +141,7 @@ editor.history.clear();
 
 #### Defined in
 
-[src/history.js:81](https://github.com/playcanvas/editor-api/blob/43e144d/src/history.js#L81)
+[src/history.js:81](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L81)
 
 ## Accessors
 
@@ -157,7 +157,7 @@ Gets the current action
 
 #### Defined in
 
-[src/history.js:90](https://github.com/playcanvas/editor-api/blob/43e144d/src/history.js#L90)
+[src/history.js:90](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L90)
 
 ___
 
@@ -173,7 +173,7 @@ Gets the last action
 
 #### Defined in
 
-[src/history.js:99](https://github.com/playcanvas/editor-api/blob/43e144d/src/history.js#L99)
+[src/history.js:99](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L99)
 
 ___
 
@@ -189,7 +189,7 @@ Whether there are any actions to undo
 
 #### Defined in
 
-[src/history.js:108](https://github.com/playcanvas/editor-api/blob/43e144d/src/history.js#L108)
+[src/history.js:108](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L108)
 
 • `set` **canUndo**(`value`): `void`
 
@@ -207,7 +207,7 @@ Whether there are any actions to undo
 
 #### Defined in
 
-[src/history.js:112](https://github.com/playcanvas/editor-api/blob/43e144d/src/history.js#L112)
+[src/history.js:112](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L112)
 
 ___
 
@@ -223,7 +223,7 @@ Whether there are actions to redo
 
 #### Defined in
 
-[src/history.js:121](https://github.com/playcanvas/editor-api/blob/43e144d/src/history.js#L121)
+[src/history.js:121](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L121)
 
 • `set` **canRedo**(`value`): `void`
 
@@ -241,4 +241,4 @@ Whether there are actions to redo
 
 #### Defined in
 
-[src/history.js:125](https://github.com/playcanvas/editor-api/blob/43e144d/src/history.js#L125)
+[src/history.js:125](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L125)

--- a/docs/classes/Jobs.md
+++ b/docs/classes/Jobs.md
@@ -33,7 +33,7 @@ Events.constructor
 
 #### Defined in
 
-[src/jobs.js:10](https://github.com/playcanvas/editor-api/blob/43e144d/src/jobs.js#L10)
+[src/jobs.js:10](https://github.com/playcanvas/editor-api/blob/a50e91b/src/jobs.js#L10)
 
 ## Methods
 
@@ -64,7 +64,7 @@ Returns a job id
 
 #### Defined in
 
-[src/jobs.js:27](https://github.com/playcanvas/editor-api/blob/43e144d/src/jobs.js#L27)
+[src/jobs.js:27](https://github.com/playcanvas/editor-api/blob/a50e91b/src/jobs.js#L27)
 
 ___
 
@@ -96,4 +96,4 @@ The function stored when the job was started
 
 #### Defined in
 
-[src/jobs.js:47](https://github.com/playcanvas/editor-api/blob/43e144d/src/jobs.js#L47)
+[src/jobs.js:47](https://github.com/playcanvas/editor-api/blob/a50e91b/src/jobs.js#L47)

--- a/docs/classes/LocalStorage.md
+++ b/docs/classes/LocalStorage.md
@@ -27,7 +27,7 @@ Constructor
 
 #### Defined in
 
-[src/localstorage.js:10](https://github.com/playcanvas/editor-api/blob/43e144d/src/localstorage.js#L10)
+[src/localstorage.js:10](https://github.com/playcanvas/editor-api/blob/a50e91b/src/localstorage.js#L10)
 
 ## Methods
 
@@ -51,7 +51,7 @@ The value
 
 #### Defined in
 
-[src/localstorage.js:20](https://github.com/playcanvas/editor-api/blob/43e144d/src/localstorage.js#L20)
+[src/localstorage.js:20](https://github.com/playcanvas/editor-api/blob/a50e91b/src/localstorage.js#L20)
 
 ___
 
@@ -74,7 +74,7 @@ Stores a key-value to localStorage
 
 #### Defined in
 
-[src/localstorage.js:48](https://github.com/playcanvas/editor-api/blob/43e144d/src/localstorage.js#L48)
+[src/localstorage.js:48](https://github.com/playcanvas/editor-api/blob/a50e91b/src/localstorage.js#L48)
 
 ___
 
@@ -96,7 +96,7 @@ Removes a key from localStorage
 
 #### Defined in
 
-[src/localstorage.js:62](https://github.com/playcanvas/editor-api/blob/43e144d/src/localstorage.js#L62)
+[src/localstorage.js:62](https://github.com/playcanvas/editor-api/blob/a50e91b/src/localstorage.js#L62)
 
 ___
 
@@ -120,4 +120,4 @@ True or false
 
 #### Defined in
 
-[src/localstorage.js:72](https://github.com/playcanvas/editor-api/blob/43e144d/src/localstorage.js#L72)
+[src/localstorage.js:72](https://github.com/playcanvas/editor-api/blob/a50e91b/src/localstorage.js#L72)

--- a/docs/classes/Messenger.md
+++ b/docs/classes/Messenger.md
@@ -45,7 +45,7 @@ Events.constructor
 
 #### Defined in
 
-[src/messenger.js:17](https://github.com/playcanvas/editor-api/blob/43e144d/src/messenger.js#L17)
+[src/messenger.js:17](https://github.com/playcanvas/editor-api/blob/a50e91b/src/messenger.js#L17)
 
 ## Methods
 
@@ -67,7 +67,7 @@ Connects to the messenger server.
 
 #### Defined in
 
-[src/messenger.js:46](https://github.com/playcanvas/editor-api/blob/43e144d/src/messenger.js#L46)
+[src/messenger.js:46](https://github.com/playcanvas/editor-api/blob/a50e91b/src/messenger.js#L46)
 
 ## Accessors
 
@@ -83,4 +83,4 @@ Returns true if we are connected to the messenger server.
 
 #### Defined in
 
-[src/messenger.js:56](https://github.com/playcanvas/editor-api/blob/43e144d/src/messenger.js#L56)
+[src/messenger.js:56](https://github.com/playcanvas/editor-api/blob/a50e91b/src/messenger.js#L56)

--- a/docs/classes/Realtime.md
+++ b/docs/classes/Realtime.md
@@ -34,7 +34,7 @@ Events.constructor
 
 #### Defined in
 
-[src/realtime.js:12](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime.js#L12)
+[src/realtime.js:12](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime.js#L12)
 
 ## Accessors
 
@@ -50,7 +50,7 @@ Gets the realtime connection
 
 #### Defined in
 
-[src/realtime.js:24](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime.js#L24)
+[src/realtime.js:24](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime.js#L24)
 
 ___
 
@@ -66,7 +66,7 @@ Gets the realtime scenes API
 
 #### Defined in
 
-[src/realtime.js:33](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime.js#L33)
+[src/realtime.js:33](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime.js#L33)
 
 ___
 
@@ -82,4 +82,4 @@ Gets the realtime assets API
 
 #### Defined in
 
-[src/realtime.js:42](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime.js#L42)
+[src/realtime.js:42](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime.js#L42)

--- a/docs/classes/RealtimeAsset.md
+++ b/docs/classes/RealtimeAsset.md
@@ -52,7 +52,7 @@ Events.constructor
 
 #### Defined in
 
-[src/realtime/asset.js:20](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/asset.js#L20)
+[src/realtime/asset.js:20](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/asset.js#L20)
 
 ## Methods
 
@@ -68,7 +68,7 @@ Loads asset from sharedb and subscribes to changes.
 
 #### Defined in
 
-[src/realtime/asset.js:34](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/asset.js#L34)
+[src/realtime/asset.js:34](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/asset.js#L34)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 ▸ **unload**(): `void`
 
-Unloads scene from sharedb and unsubscribes from changes.
+Unloads asset from sharedb and unsubscribes from changes.
 
 #### Returns
 
@@ -84,7 +84,7 @@ Unloads scene from sharedb and unsubscribes from changes.
 
 #### Defined in
 
-[src/realtime/asset.js:49](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/asset.js#L49)
+[src/realtime/asset.js:49](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/asset.js#L49)
 
 ___
 
@@ -106,7 +106,7 @@ Submits sharedb operation
 
 #### Defined in
 
-[src/realtime/asset.js:68](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/asset.js#L68)
+[src/realtime/asset.js:68](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/asset.js#L68)
 
 ___
 
@@ -129,7 +129,7 @@ sent to the server
 
 #### Defined in
 
-[src/realtime/asset.js:85](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/asset.js#L85)
+[src/realtime/asset.js:85](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/asset.js#L85)
 
 ## Accessors
 
@@ -145,7 +145,7 @@ Whether the asset is loaded
 
 #### Defined in
 
-[src/realtime/asset.js:131](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/asset.js#L131)
+[src/realtime/asset.js:131](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/asset.js#L131)
 
 ___
 
@@ -161,7 +161,7 @@ The asset data
 
 #### Defined in
 
-[src/realtime/asset.js:140](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/asset.js#L140)
+[src/realtime/asset.js:140](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/asset.js#L140)
 
 ___
 
@@ -177,7 +177,7 @@ The asset id - used in combination with branch id
 
 #### Defined in
 
-[src/realtime/asset.js:149](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/asset.js#L149)
+[src/realtime/asset.js:149](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/asset.js#L149)
 
 ___
 
@@ -193,4 +193,4 @@ The asset's unique id
 
 #### Defined in
 
-[src/realtime/asset.js:158](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/asset.js#L158)
+[src/realtime/asset.js:158](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/asset.js#L158)

--- a/docs/classes/RealtimeAssets.md
+++ b/docs/classes/RealtimeAssets.md
@@ -43,7 +43,7 @@ Events.constructor
 
 #### Defined in
 
-[src/realtime/assets.js:19](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/assets.js#L19)
+[src/realtime/assets.js:19](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/assets.js#L19)
 
 ## Methods
 
@@ -67,7 +67,7 @@ The asset
 
 #### Defined in
 
-[src/realtime/assets.js:32](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/assets.js#L32)
+[src/realtime/assets.js:32](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/assets.js#L32)
 
 ___
 
@@ -91,7 +91,7 @@ The asset
 
 #### Defined in
 
-[src/realtime/assets.js:52](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/assets.js#L52)
+[src/realtime/assets.js:52](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/assets.js#L52)
 
 ___
 
@@ -113,4 +113,4 @@ Unloads an asset
 
 #### Defined in
 
-[src/realtime/assets.js:61](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/assets.js#L61)
+[src/realtime/assets.js:61](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/assets.js#L61)

--- a/docs/classes/RealtimeConnection.md
+++ b/docs/classes/RealtimeConnection.md
@@ -52,7 +52,7 @@ Events.constructor
 
 #### Defined in
 
-[src/realtime/connection.js:20](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/connection.js#L20)
+[src/realtime/connection.js:20](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/connection.js#L20)
 
 ## Methods
 
@@ -74,7 +74,7 @@ Connect to the realtime server
 
 #### Defined in
 
-[src/realtime/connection.js:39](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/connection.js#L39)
+[src/realtime/connection.js:39](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/connection.js#L39)
 
 ___
 
@@ -90,7 +90,7 @@ Disconnect from the server
 
 #### Defined in
 
-[src/realtime/connection.js:77](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/connection.js#L77)
+[src/realtime/connection.js:77](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/connection.js#L77)
 
 ___
 
@@ -113,7 +113,7 @@ Send message to server
 
 #### Defined in
 
-[src/realtime/connection.js:91](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/connection.js#L91)
+[src/realtime/connection.js:91](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/connection.js#L91)
 
 ___
 
@@ -135,7 +135,7 @@ Sends a string to the server
 
 #### Defined in
 
-[src/realtime/connection.js:100](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/connection.js#L100)
+[src/realtime/connection.js:100](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/connection.js#L100)
 
 ___
 
@@ -160,7 +160,7 @@ The sharedb document
 
 #### Defined in
 
-[src/realtime/connection.js:113](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/connection.js#L113)
+[src/realtime/connection.js:113](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/connection.js#L113)
 
 ___
 
@@ -176,7 +176,7 @@ Start bulk subscribing to documents
 
 #### Defined in
 
-[src/realtime/connection.js:120](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/connection.js#L120)
+[src/realtime/connection.js:120](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/connection.js#L120)
 
 ___
 
@@ -192,7 +192,7 @@ Stop bulk subscribing to documents
 
 #### Defined in
 
-[src/realtime/connection.js:127](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/connection.js#L127)
+[src/realtime/connection.js:127](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/connection.js#L127)
 
 ## Accessors
 
@@ -208,7 +208,7 @@ Whether the user is connected to the server
 
 #### Defined in
 
-[src/realtime/connection.js:228](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/connection.js#L228)
+[src/realtime/connection.js:228](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/connection.js#L228)
 
 ___
 
@@ -224,7 +224,7 @@ Whether the server has authenticated the user
 
 #### Defined in
 
-[src/realtime/connection.js:237](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/connection.js#L237)
+[src/realtime/connection.js:237](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/connection.js#L237)
 
 ___
 
@@ -240,4 +240,4 @@ Gets the sharedb instance
 
 #### Defined in
 
-[src/realtime/connection.js:246](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/connection.js#L246)
+[src/realtime/connection.js:246](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/connection.js#L246)

--- a/docs/classes/RealtimeScene.md
+++ b/docs/classes/RealtimeScene.md
@@ -54,7 +54,7 @@ Events.constructor
 
 #### Defined in
 
-[src/realtime/scene.js:20](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/scene.js#L20)
+[src/realtime/scene.js:20](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scene.js#L20)
 
 ## Methods
 
@@ -70,7 +70,7 @@ Loads scene from sharedb and subscribes to changes.
 
 #### Defined in
 
-[src/realtime/scene.js:34](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/scene.js#L34)
+[src/realtime/scene.js:34](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scene.js#L34)
 
 ___
 
@@ -86,7 +86,7 @@ Unloads scene from sharedb and unsubscribes from changes.
 
 #### Defined in
 
-[src/realtime/scene.js:49](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/scene.js#L49)
+[src/realtime/scene.js:49](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scene.js#L49)
 
 ___
 
@@ -108,7 +108,7 @@ Add entity to scene
 
 #### Defined in
 
-[src/realtime/scene.js:70](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/scene.js#L70)
+[src/realtime/scene.js:70](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scene.js#L70)
 
 ___
 
@@ -130,7 +130,7 @@ Removes entity from scene (not from children of another entity)
 
 #### Defined in
 
-[src/realtime/scene.js:82](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/scene.js#L82)
+[src/realtime/scene.js:82](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scene.js#L82)
 
 ___
 
@@ -152,7 +152,7 @@ Submits sharedb operation
 
 #### Defined in
 
-[src/realtime/scene.js:94](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/scene.js#L94)
+[src/realtime/scene.js:94](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scene.js#L94)
 
 ___
 
@@ -175,7 +175,7 @@ sent to the server
 
 #### Defined in
 
-[src/realtime/scene.js:111](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/scene.js#L111)
+[src/realtime/scene.js:111](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scene.js#L111)
 
 ## Accessors
 
@@ -191,7 +191,7 @@ Whether the scene is loaded
 
 #### Defined in
 
-[src/realtime/scene.js:143](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/scene.js#L143)
+[src/realtime/scene.js:143](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scene.js#L143)
 
 ___
 
@@ -207,7 +207,7 @@ The scene data
 
 #### Defined in
 
-[src/realtime/scene.js:152](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/scene.js#L152)
+[src/realtime/scene.js:152](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scene.js#L152)
 
 ___
 
@@ -223,7 +223,7 @@ The scene id - used in combination with the branch id
 
 #### Defined in
 
-[src/realtime/scene.js:161](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/scene.js#L161)
+[src/realtime/scene.js:161](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scene.js#L161)
 
 ___
 
@@ -239,4 +239,4 @@ The scene's unique id
 
 #### Defined in
 
-[src/realtime/scene.js:170](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/scene.js#L170)
+[src/realtime/scene.js:170](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scene.js#L170)

--- a/docs/classes/RealtimeScenes.md
+++ b/docs/classes/RealtimeScenes.md
@@ -46,7 +46,7 @@ Events.constructor
 
 #### Defined in
 
-[src/realtime/scenes.js:19](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/scenes.js#L19)
+[src/realtime/scenes.js:19](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scenes.js#L19)
 
 ## Methods
 
@@ -70,7 +70,7 @@ The scene
 
 #### Defined in
 
-[src/realtime/scenes.js:33](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/scenes.js#L33)
+[src/realtime/scenes.js:33](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scenes.js#L33)
 
 ___
 
@@ -92,7 +92,7 @@ Unloads a scene
 
 #### Defined in
 
-[src/realtime/scenes.js:56](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/scenes.js#L56)
+[src/realtime/scenes.js:56](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scenes.js#L56)
 
 ## Accessors
 
@@ -108,4 +108,4 @@ The current scene
 
 #### Defined in
 
-[src/realtime/scenes.js:72](https://github.com/playcanvas/editor-api/blob/43e144d/src/realtime/scenes.js#L72)
+[src/realtime/scenes.js:72](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scenes.js#L72)

--- a/docs/classes/SceneSettings.md
+++ b/docs/classes/SceneSettings.md
@@ -1,0 +1,150 @@
+[PlayCanvas Editor API](../README.md) / [Exports](../modules.md) / SceneSettings
+
+# Class: SceneSettings
+
+Represents the settings for the currently loaded scene.
+For a list of properties see [here](SceneSettingsProperties.md).
+
+## Hierarchy
+
+- `Events`
+
+  ↳ **`SceneSettings`**
+
+## Table of contents
+
+### Methods
+
+- [has](SceneSettings.md#has)
+- [get](SceneSettings.md#get)
+- [set](SceneSettings.md#set)
+- [json](SceneSettings.md#json)
+
+### Accessors
+
+- [history](SceneSettings.md#history)
+
+## Methods
+
+### has
+
+▸ **has**(`path`): `boolean`
+
+Checks if path exists. See [here](SceneSettingsProperties.md) for a list of properties.
+
+**`example`**
+```javascript
+console.log(editor.settings.scene.has('render.fog'));
+```
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `path` | `string` | The path |
+
+#### Returns
+
+`boolean`
+
+True if path exists
+
+#### Defined in
+
+[src/settings/scene.js:73](https://github.com/playcanvas/editor-api/blob/a50e91b/src/settings/scene.js#L73)
+
+___
+
+### get
+
+▸ **get**(`path`): `any`
+
+Gets value at path. See [here](SceneSettingsProperties.md) for a list of properties.
+
+**`example`**
+```javascript
+console.log(editor.settings.scene.get('render.fog'));
+```
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `path` | `string` | The path |
+
+#### Returns
+
+`any`
+
+The value
+
+#### Defined in
+
+[src/settings/scene.js:87](https://github.com/playcanvas/editor-api/blob/a50e91b/src/settings/scene.js#L87)
+
+___
+
+### set
+
+▸ **set**(`path`, `value`): `boolean`
+
+Sets value at path. See [here](SceneSettingsProperties.md) for a list of properties.
+
+**`example`**
+```javascript
+editor.settings.scene.set('render.fog', 'none');
+```
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `path` | `string` | The path |
+| `value` | `any` | The value |
+
+#### Returns
+
+`boolean`
+
+Whether the value was set
+
+#### Defined in
+
+[src/settings/scene.js:102](https://github.com/playcanvas/editor-api/blob/a50e91b/src/settings/scene.js#L102)
+
+___
+
+### json
+
+▸ **json**(): `any`
+
+Returns JSON representation of scene settings data
+
+#### Returns
+
+`any`
+
+- The data
+```javascript
+console.log(editor.settings.scene.json());
+```
+
+#### Defined in
+
+[src/settings/scene.js:114](https://github.com/playcanvas/editor-api/blob/a50e91b/src/settings/scene.js#L114)
+
+## Accessors
+
+### history
+
+• `get` **history**(): `any`
+
+Gets the history object for this entity
+
+#### Returns
+
+`any`
+
+#### Defined in
+
+[src/settings/scene.js:123](https://github.com/playcanvas/editor-api/blob/a50e91b/src/settings/scene.js#L123)

--- a/docs/classes/SceneSettingsProperties.md
+++ b/docs/classes/SceneSettingsProperties.md
@@ -1,0 +1,27 @@
+[PlayCanvas Editor API](../README.md) / [Exports](../modules.md) / [Scene Settings](SceneSettings.md) / Properties
+
+# Scene Settings Properties #
+
+These are the properties that you can access on the [SceneSettings](SceneSettings.md):
+
+| Path | Type | Description | Default Value | 
+| :------ | :------ | :------ | :------ |
+| `physics` | `object` | Physics related settings for the scene. |  | 
+| `physics.gravity` | `Array<number>` | An array of 3 numbers that represents the gravity force. |  | 
+| `render` | `object` | Render settings for the scene. |  | 
+| `render.exposure` | `number` | The exposure value tweaks the overall brightness of the scene. |  | 
+| `render.fog` | `string` | The type of fog used in the scene. Can be one of `pc.FOG_NONE`, `pc.FOG_LINEAR`, `pc.FOG_EXP`, `pc.FOG_EXP2`. |  | 
+| `render.fog_color` | `Array<number>` | An array of 3 numbers representing the color of the fog. |  | 
+| `render.fog_density` | `number` | The density of the fog. This property is only valid if the fog property is set to `pc.FOG_EXP` or `pc.FOG_EXP2`. |  | 
+| `render.fog_end` | `number` | The distance from the viewpoint where linear fog reaches its maximum. This property is only valid if the fog property is set to `pc.FOG_LINEAR`. |  | 
+| `render.fog_start` | `number` | The distance from the viewpoint where linear fog begins. This property is only valid if the fog property is set to `pc.FOG_LINEAR`. |  | 
+| `render.gamma_correction` | `number` | The gamma correction to apply when rendering the scene. Can be one of `pc.GAMMA_NONE`, `pc.GAMMA_SRGB`. |  | 
+| `render.global_ambient` | `Array<number>` | An array of 3 numbers representing the color of the scene's ambient light. |  | 
+| `render.lightmapMaxResolution` | `number` | The maximum lightmap resolution. |  | 
+| `render.lightmapMode` | `number` | The lightmap baking mode. Can be one of `pc.BAKE_COLOR`, `pc.BAKE_COLORDIR`. |  | 
+| `render.lightmapSizeMultiplier` | `number` | The lightmap resolution multiplier. |  | 
+| `render.skybox` | `number` | The `id` of the cubemap texture to be used as the scene's skybox. |  | 
+| `render.skyboxIntensity` | `number` | Multiplier for skybox intensity. |  | 
+| `render.skyboxMip` | `number` | The mip level of the skybox to be displayed. Only valid for prefiltered cubemap skyboxes. |  | 
+| `render.skyboxRotation` | `Array<number>` | An array of 3 numbers representing the rotation of the skybox. | `[0,0,0]`| 
+| `render.tonemapping` | `number` | The tonemapping transform to apply when writing fragments to the frame buffer. Can be: `pc.TONEMAP_LINEAR`, `pc.TONEMAP_FILMIC`, `pc.TONEMAP_HEJL`, `pc.TONEMAP_ACES`. |  | 

--- a/docs/classes/Schema.md
+++ b/docs/classes/Schema.md
@@ -35,7 +35,7 @@ Creates new instance of API
 
 #### Defined in
 
-[src/schema.js:13](https://github.com/playcanvas/editor-api/blob/43e144d/src/schema.js#L13)
+[src/schema.js:13](https://github.com/playcanvas/editor-api/blob/a50e91b/src/schema.js#L13)
 
 ## Accessors
 
@@ -51,7 +51,7 @@ Gets the component schema
 
 #### Defined in
 
-[src/schema.js:24](https://github.com/playcanvas/editor-api/blob/43e144d/src/schema.js#L24)
+[src/schema.js:24](https://github.com/playcanvas/editor-api/blob/a50e91b/src/schema.js#L24)
 
 ___
 
@@ -67,7 +67,7 @@ Gets the assets schema
 
 #### Defined in
 
-[src/schema.js:33](https://github.com/playcanvas/editor-api/blob/43e144d/src/schema.js#L33)
+[src/schema.js:33](https://github.com/playcanvas/editor-api/blob/a50e91b/src/schema.js#L33)
 
 ## Internal Methods
 
@@ -92,4 +92,4 @@ The type
 
 #### Defined in
 
-[src/schema.js:45](https://github.com/playcanvas/editor-api/blob/43e144d/src/schema.js#L45)
+[src/schema.js:45](https://github.com/playcanvas/editor-api/blob/a50e91b/src/schema.js#L45)

--- a/docs/classes/Selection.md
+++ b/docs/classes/Selection.md
@@ -49,7 +49,7 @@ Events.constructor
 
 #### Defined in
 
-[src/selection.js:80](https://github.com/playcanvas/editor-api/blob/43e144d/src/selection.js#L80)
+[src/selection.js:80](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L80)
 
 ## Methods
 
@@ -79,7 +79,7 @@ editor.selection.add(editor.entities.root);
 
 #### Defined in
 
-[src/selection.js:114](https://github.com/playcanvas/editor-api/blob/43e144d/src/selection.js#L114)
+[src/selection.js:114](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L114)
 
 ___
 
@@ -109,7 +109,7 @@ editor.selection.remove(editor.entities.root);
 
 #### Defined in
 
-[src/selection.js:150](https://github.com/playcanvas/editor-api/blob/43e144d/src/selection.js#L150)
+[src/selection.js:150](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L150)
 
 ___
 
@@ -139,7 +139,7 @@ editor.selection.toogle(editor.entities.root);
 
 #### Defined in
 
-[src/selection.js:185](https://github.com/playcanvas/editor-api/blob/43e144d/src/selection.js#L185)
+[src/selection.js:185](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L185)
 
 ___
 
@@ -168,7 +168,7 @@ If item is in selection
 
 #### Defined in
 
-[src/selection.js:221](https://github.com/playcanvas/editor-api/blob/43e144d/src/selection.js#L221)
+[src/selection.js:221](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L221)
 
 ___
 
@@ -196,7 +196,7 @@ editor.selection.clear();
 
 #### Defined in
 
-[src/selection.js:235](https://github.com/playcanvas/editor-api/blob/43e144d/src/selection.js#L235)
+[src/selection.js:235](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L235)
 
 ___
 
@@ -226,7 +226,7 @@ editor.selection.set([editor.entities.root]);
 
 #### Defined in
 
-[src/selection.js:278](https://github.com/playcanvas/editor-api/blob/43e144d/src/selection.js#L278)
+[src/selection.js:278](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L278)
 
 ## Accessors
 
@@ -248,7 +248,7 @@ const selectedEntities = editor.selection.items;
 
 #### Defined in
 
-[src/selection.js:312](https://github.com/playcanvas/editor-api/blob/43e144d/src/selection.js#L312)
+[src/selection.js:312](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L312)
 
 ___
 
@@ -264,7 +264,7 @@ Gets the first selected item. Short for this.items[0].
 
 #### Defined in
 
-[src/selection.js:321](https://github.com/playcanvas/editor-api/blob/43e144d/src/selection.js#L321)
+[src/selection.js:321](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L321)
 
 ___
 
@@ -280,7 +280,7 @@ Enables / disables the selection methods
 
 #### Defined in
 
-[src/selection.js:330](https://github.com/playcanvas/editor-api/blob/43e144d/src/selection.js#L330)
+[src/selection.js:330](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L330)
 
 • `set` **enabled**(`value`): `void`
 
@@ -298,7 +298,7 @@ Enables / disables the selection methods
 
 #### Defined in
 
-[src/selection.js:334](https://github.com/playcanvas/editor-api/blob/43e144d/src/selection.js#L334)
+[src/selection.js:334](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L334)
 
 ___
 
@@ -314,7 +314,7 @@ Gets the number of selected items
 
 #### Defined in
 
-[src/selection.js:343](https://github.com/playcanvas/editor-api/blob/43e144d/src/selection.js#L343)
+[src/selection.js:343](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L343)
 
 ___
 
@@ -330,4 +330,4 @@ Gets the selection history
 
 #### Defined in
 
-[src/selection.js:352](https://github.com/playcanvas/editor-api/blob/43e144d/src/selection.js#L352)
+[src/selection.js:352](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L352)

--- a/docs/classes/SelectionHistory.md
+++ b/docs/classes/SelectionHistory.md
@@ -32,7 +32,7 @@ Constructor
 
 #### Defined in
 
-[src/selection.js:14](https://github.com/playcanvas/editor-api/blob/43e144d/src/selection.js#L14)
+[src/selection.js:14](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L14)
 
 ## Accessors
 
@@ -48,7 +48,7 @@ Disables / enables selection undo / redo
 
 #### Defined in
 
-[src/selection.js:25](https://github.com/playcanvas/editor-api/blob/43e144d/src/selection.js#L25)
+[src/selection.js:25](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L25)
 
 • `set` **enabled**(`value`): `void`
 
@@ -66,4 +66,4 @@ Disables / enables selection undo / redo
 
 #### Defined in
 
-[src/selection.js:29](https://github.com/playcanvas/editor-api/blob/43e144d/src/selection.js#L29)
+[src/selection.js:29](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L29)

--- a/docs/classes/Settings.md
+++ b/docs/classes/Settings.md
@@ -1,0 +1,53 @@
+[PlayCanvas Editor API](../README.md) / [Exports](../modules.md) / Settings
+
+# Class: Settings
+
+The settings editor API
+
+## Hierarchy
+
+- `Events`
+
+  ↳ **`Settings`**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](Settings.md#constructor)
+
+### Accessors
+
+- [scene](Settings.md#scene)
+
+## Constructors
+
+### constructor
+
+• **new Settings**()
+
+Creates new API instance
+
+#### Overrides
+
+Events.constructor
+
+#### Defined in
+
+[src/settings.js:11](https://github.com/playcanvas/editor-api/blob/a50e91b/src/settings.js#L11)
+
+## Accessors
+
+### scene
+
+• `get` **scene**(): [`SceneSettings`](SceneSettings.md)
+
+Gets the settings for the currently loaded scene.
+
+#### Returns
+
+[`SceneSettings`](SceneSettings.md)
+
+#### Defined in
+
+[src/settings.js:22](https://github.com/playcanvas/editor-api/blob/a50e91b/src/settings.js#L22)

--- a/docs/classes/globals.md
+++ b/docs/classes/globals.md
@@ -13,6 +13,7 @@ Global variables
 - [schema](globals.md#schema)
 - [assets](globals.md#assets)
 - [entities](globals.md#entities)
+- [settings](globals.md#settings)
 - [projectId](globals.md#projectid)
 - [branchId](globals.md#branchid)
 
@@ -43,7 +44,7 @@ The history API
 
 #### Defined in
 
-[src/globals.js:10](https://github.com/playcanvas/editor-api/blob/43e144d/src/globals.js#L10)
+[src/globals.js:10](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L10)
 
 ___
 
@@ -55,7 +56,7 @@ The selection API
 
 #### Defined in
 
-[src/globals.js:17](https://github.com/playcanvas/editor-api/blob/43e144d/src/globals.js#L17)
+[src/globals.js:17](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L17)
 
 ___
 
@@ -67,7 +68,7 @@ The schema API
 
 #### Defined in
 
-[src/globals.js:24](https://github.com/playcanvas/editor-api/blob/43e144d/src/globals.js#L24)
+[src/globals.js:24](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L24)
 
 ___
 
@@ -79,7 +80,7 @@ The assets API
 
 #### Defined in
 
-[src/globals.js:39](https://github.com/playcanvas/editor-api/blob/43e144d/src/globals.js#L39)
+[src/globals.js:39](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L39)
 
 ___
 
@@ -91,7 +92,19 @@ The entities API
 
 #### Defined in
 
-[src/globals.js:46](https://github.com/playcanvas/editor-api/blob/43e144d/src/globals.js#L46)
+[src/globals.js:46](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L46)
+
+___
+
+### settings
+
+▪ `Static` **settings**: [`Settings`](Settings.md)
+
+The settings API
+
+#### Defined in
+
+[src/globals.js:53](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L53)
 
 ___
 
@@ -103,7 +116,7 @@ The current project id
 
 #### Defined in
 
-[src/globals.js:85](https://github.com/playcanvas/editor-api/blob/43e144d/src/globals.js#L85)
+[src/globals.js:92](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L92)
 
 ___
 
@@ -115,7 +128,7 @@ The current branch id
 
 #### Defined in
 
-[src/globals.js:92](https://github.com/playcanvas/editor-api/blob/43e144d/src/globals.js#L92)
+[src/globals.js:99](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L99)
 
 ___
 
@@ -129,7 +142,7 @@ The realtime API
 
 #### Defined in
 
-[src/globals.js:32](https://github.com/playcanvas/editor-api/blob/43e144d/src/globals.js#L32)
+[src/globals.js:32](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L32)
 
 ___
 
@@ -141,7 +154,7 @@ The messenger API
 
 #### Defined in
 
-[src/globals.js:54](https://github.com/playcanvas/editor-api/blob/43e144d/src/globals.js#L54)
+[src/globals.js:61](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L61)
 
 ___
 
@@ -153,7 +166,7 @@ The jobs API
 
 #### Defined in
 
-[src/globals.js:62](https://github.com/playcanvas/editor-api/blob/43e144d/src/globals.js#L62)
+[src/globals.js:69](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L69)
 
 ___
 
@@ -165,7 +178,7 @@ The main clipboard
 
 #### Defined in
 
-[src/globals.js:70](https://github.com/playcanvas/editor-api/blob/43e144d/src/globals.js#L70)
+[src/globals.js:77](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L77)
 
 ___
 
@@ -177,7 +190,7 @@ The user's access token
 
 #### Defined in
 
-[src/globals.js:78](https://github.com/playcanvas/editor-api/blob/43e144d/src/globals.js#L78)
+[src/globals.js:85](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L85)
 
 ___
 
@@ -189,7 +202,7 @@ Whether this project is using legacy scripts
 
 #### Defined in
 
-[src/globals.js:100](https://github.com/playcanvas/editor-api/blob/43e144d/src/globals.js#L100)
+[src/globals.js:107](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L107)
 
 ## Methods
 
@@ -219,7 +232,7 @@ True if the user confirmed, false otherwise
 
 #### Defined in
 
-[src/globals.js:114](https://github.com/playcanvas/editor-api/blob/43e144d/src/globals.js#L114)
+[src/globals.js:121](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L121)
 
 ## Constructors
 

--- a/docs/classes/utils.md
+++ b/docs/classes/utils.md
@@ -36,7 +36,7 @@ A copy of the data
 
 #### Defined in
 
-[src/utils.js:13](https://github.com/playcanvas/editor-api/blob/43e144d/src/utils.js#L13)
+[src/utils.js:13](https://github.com/playcanvas/editor-api/blob/a50e91b/src/utils.js#L13)
 
 ## Constructors
 

--- a/docs/interfaces/AssetUploadArguments.md
+++ b/docs/interfaces/AssetUploadArguments.md
@@ -27,7 +27,7 @@ The parent folder asset where the asset should be placed.
 
 #### Defined in
 
-[src/assets.js:13](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L13)
+[src/assets.js:13](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L13)
 
 ___
 
@@ -39,7 +39,7 @@ The filename of the uploaded file.
 
 #### Defined in
 
-[src/assets.js:14](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L14)
+[src/assets.js:14](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L14)
 
 ___
 
@@ -51,7 +51,7 @@ The file being uploaded.
 
 #### Defined in
 
-[src/assets.js:15](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L15)
+[src/assets.js:15](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L15)
 
 ___
 
@@ -63,7 +63,7 @@ The type of the asset we are uploading. See [here](AssetProperties.md) for avail
 
 #### Defined in
 
-[src/assets.js:16](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L16)
+[src/assets.js:16](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L16)
 
 ___
 
@@ -75,7 +75,7 @@ The name of the asset.
 
 #### Defined in
 
-[src/assets.js:17](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L17)
+[src/assets.js:17](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L17)
 
 ___
 
@@ -87,7 +87,7 @@ The tags of the asset.
 
 #### Defined in
 
-[src/assets.js:18](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L18)
+[src/assets.js:18](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L18)
 
 ___
 
@@ -99,7 +99,7 @@ The id of the source asset.
 
 #### Defined in
 
-[src/assets.js:19](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L19)
+[src/assets.js:19](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L19)
 
 ___
 
@@ -111,7 +111,7 @@ The asset data. This depends on the asset type. See [here](AssetProperties.md) f
 
 #### Defined in
 
-[src/assets.js:20](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L20)
+[src/assets.js:20](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L20)
 
 ___
 
@@ -123,7 +123,7 @@ Whether to preload the asset. Defaults to true.
 
 #### Defined in
 
-[src/assets.js:21](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L21)
+[src/assets.js:21](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L21)
 
 ___
 
@@ -135,4 +135,4 @@ If an asset id is specified then this asset will be updated instead of creating 
 
 #### Defined in
 
-[src/assets.js:22](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L22)
+[src/assets.js:22](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L22)

--- a/docs/interfaces/CreateEntityArguments.md
+++ b/docs/interfaces/CreateEntityArguments.md
@@ -27,7 +27,7 @@ The entity name
 
 #### Defined in
 
-[src/entities.js:18](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L18)
+[src/entities.js:18](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L18)
 
 ___
 
@@ -39,7 +39,7 @@ Component data. See [here](EntityProperties.md) for details on component data.
 
 #### Defined in
 
-[src/entities.js:19](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L19)
+[src/entities.js:19](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L19)
 
 ___
 
@@ -51,7 +51,7 @@ The parent Entity or its resource_id. If undefined then the root Entity will be 
 
 #### Defined in
 
-[src/entities.js:20](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L20)
+[src/entities.js:20](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L20)
 
 ___
 
@@ -63,7 +63,7 @@ Data for child entities.
 
 #### Defined in
 
-[src/entities.js:21](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L21)
+[src/entities.js:21](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L21)
 
 ___
 
@@ -75,7 +75,7 @@ Tags for the Entity.
 
 #### Defined in
 
-[src/entities.js:22](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L22)
+[src/entities.js:22](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L22)
 
 ___
 
@@ -87,7 +87,7 @@ Whether the Entity should be enabled.
 
 #### Defined in
 
-[src/entities.js:23](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L23)
+[src/entities.js:23](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L23)
 
 ___
 
@@ -99,7 +99,7 @@ The resource_id of the Entity. Leave undefined to generate a new one.
 
 #### Defined in
 
-[src/entities.js:24](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L24)
+[src/entities.js:24](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L24)
 
 ___
 
@@ -111,7 +111,7 @@ The position of the Entity in local space.
 
 #### Defined in
 
-[src/entities.js:25](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L25)
+[src/entities.js:25](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L25)
 
 ___
 
@@ -123,7 +123,7 @@ The rotation of the Entity in local space (euler angles in degrees).
 
 #### Defined in
 
-[src/entities.js:26](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L26)
+[src/entities.js:26](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L26)
 
 ___
 
@@ -135,4 +135,4 @@ The scale of the Entity in local space.
 
 #### Defined in
 
-[src/entities.js:27](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L27)
+[src/entities.js:27](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L27)

--- a/docs/interfaces/HistoryAction.md
+++ b/docs/interfaces/HistoryAction.md
@@ -20,7 +20,7 @@ The action name
 
 #### Defined in
 
-[src/history.js:7](https://github.com/playcanvas/editor-api/blob/43e144d/src/history.js#L7)
+[src/history.js:7](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L7)
 
 ___
 
@@ -32,7 +32,7 @@ The undo function
 
 #### Defined in
 
-[src/history.js:8](https://github.com/playcanvas/editor-api/blob/43e144d/src/history.js#L8)
+[src/history.js:8](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L8)
 
 ___
 
@@ -44,4 +44,4 @@ The redo function
 
 #### Defined in
 
-[src/history.js:9](https://github.com/playcanvas/editor-api/blob/43e144d/src/history.js#L9)
+[src/history.js:9](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L9)

--- a/docs/interfaces/ReparentArguments.md
+++ b/docs/interfaces/ReparentArguments.md
@@ -20,7 +20,7 @@ The entity to reparent
 
 #### Defined in
 
-[src/entities.js:34](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L34)
+[src/entities.js:34](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L34)
 
 ___
 
@@ -32,7 +32,7 @@ The new parent for the entity
 
 #### Defined in
 
-[src/entities.js:35](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L35)
+[src/entities.js:35](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L35)
 
 ___
 
@@ -44,4 +44,4 @@ The child index of the entity under the new parent
 
 #### Defined in
 
-[src/entities.js:36](https://github.com/playcanvas/editor-api/blob/43e144d/src/entities.js#L36)
+[src/entities.js:36](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L36)

--- a/docs/interfaces/SceneImportSettings.md
+++ b/docs/interfaces/SceneImportSettings.md
@@ -29,7 +29,7 @@ throughout the whole project instead of just the same folder. Defaults to true.
 
 #### Defined in
 
-[src/assets.js:38](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L38)
+[src/assets.js:38](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L38)
 
 ___
 
@@ -41,7 +41,7 @@ Whether to overwrite existing model or create a new one. Defaults to true.
 
 #### Defined in
 
-[src/assets.js:40](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L40)
+[src/assets.js:40](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L40)
 
 ___
 
@@ -53,7 +53,7 @@ Whether to overwrite existing animations or create new ones. Defaults to true.
 
 #### Defined in
 
-[src/assets.js:41](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L41)
+[src/assets.js:41](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L41)
 
 ___
 
@@ -65,7 +65,7 @@ Whether to overwrite existing materials or create new ones. Defaults to true.
 
 #### Defined in
 
-[src/assets.js:42](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L42)
+[src/assets.js:42](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L42)
 
 ___
 
@@ -77,7 +77,7 @@ Whether to overwrite existing textures or create new ones. Defaults to true.
 
 #### Defined in
 
-[src/assets.js:43](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L43)
+[src/assets.js:43](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L43)
 
 ___
 
@@ -89,7 +89,7 @@ Whether to resize embedded textures to power of 2. Defaults to true.
 
 #### Defined in
 
-[src/assets.js:44](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L44)
+[src/assets.js:44](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L44)
 
 ___
 
@@ -101,7 +101,7 @@ Whether to convert models to GLB. Defaults to true.
 
 #### Defined in
 
-[src/assets.js:45](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L45)
+[src/assets.js:45](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L45)
 
 ___
 
@@ -113,7 +113,7 @@ The desired animation sample rate. Defaults to 10.
 
 #### Defined in
 
-[src/assets.js:46](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L46)
+[src/assets.js:46](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L46)
 
 ___
 
@@ -125,7 +125,7 @@ The animation curve tolerance. Defaults to 0.
 
 #### Defined in
 
-[src/assets.js:47](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L47)
+[src/assets.js:47](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L47)
 
 ___
 
@@ -137,7 +137,7 @@ Whether to enable cubic curves. Defaults to false.
 
 #### Defined in
 
-[src/assets.js:48](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L48)
+[src/assets.js:48](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L48)
 
 ___
 
@@ -149,4 +149,4 @@ Whether to use the fbx filename for animation names. Defaults to false.
 
 #### Defined in
 
-[src/assets.js:49](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L49)
+[src/assets.js:49](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L49)

--- a/docs/interfaces/TextureImportSettings.md
+++ b/docs/interfaces/TextureImportSettings.md
@@ -19,7 +19,7 @@ Whether to resize the texture to power of 2.
 
 #### Defined in
 
-[src/assets.js:29](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L29)
+[src/assets.js:29](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L29)
 
 ___
 
@@ -32,4 +32,4 @@ throughout the whole project instead of just the same folder.
 
 #### Defined in
 
-[src/assets.js:30](https://github.com/playcanvas/editor-api/blob/43e144d/src/assets.js#L30)
+[src/assets.js:30](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L30)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -17,6 +17,8 @@
 - [ComponentSchema](classes/ComponentSchema.md)
 - [SelectionHistory](classes/SelectionHistory.md)
 - [Selection](classes/Selection.md)
+- [Settings](classes/Settings.md)
+- [SceneSettings](classes/SceneSettings.md)
 
 ### Internal Classes
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ export * from './src/entities';
 export * from './src/entity';
 export * from './src/assets';
 export * from './src/asset';
+export * from './src/settings';
+export * from './src/settings/scene';
 export * from './src/history';
 export * from './src/selection';
 export * from './src/schema';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "editor-api",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "editor-api",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "The PlayCanvas Editor API",
   "main": "index.js",
   "module": "index.mjs",

--- a/src/asset.js
+++ b/src/asset.js
@@ -1,5 +1,6 @@
 import { globals as api } from './globals';
 import { Events, Observer, ObserverHistory } from '@playcanvas/observer';
+import { replace } from './assets/replace';
 
 /**
  * Represents an Asset. For a list of Asset properties see [here](AssetProperties.md).
@@ -273,6 +274,18 @@ class Asset extends Events {
     async instantiateTemplate(parent, options) {
         const entities = await api.assets.instantiateTemplates([this], parent, options);
         return entities[0];
+    }
+
+    /**
+     * Replaces any references to this asset with
+     * references to the new asset specified.
+     *
+     * @param {Asset} asset - The new asset.
+     * @param {object} options - Options.
+     * @param {boolean} options.history - Whether to record a history action.
+     */
+    replace(asset, options = {}) {
+        replace(this, asset, options);
     }
 
     /**

--- a/src/assets/replace.js
+++ b/src/assets/replace.js
@@ -1,0 +1,167 @@
+import { globals as api } from '../globals';
+import { findAssetReferencesInComponents, updateReferences } from '../entities/references';
+import { utils } from '../utils';
+
+const REGEX_MODEL_DATA_MAPPING = /^data\.mapping\.(\d+)\.material$/;
+
+// Replace references in components or script attributes
+function replaceEntityRefs(oldAsset, newAsset, options) {
+    const oldId = parseInt(oldAsset.get('id'), 10);
+    const newId = parseInt(newAsset.get('id'), 10);
+
+    const records = [];
+
+    const refs = findAssetReferencesInComponents(api.entities.root);
+    if (refs[oldId]) {
+        // remember previous values
+        refs[oldId].forEach((ref) => {
+            const entity = api.entities.get(ref.entityId);
+            records.push({
+                obj: entity,
+                path: ref.path,
+                value: entity.get(ref.path)
+            });
+        });
+
+        // update references
+        updateReferences(refs, oldId, newId);
+    }
+
+    return records;
+}
+
+function replaceAssetRefs(oldAsset, newAsset, options) {
+    const oldId = parseInt(oldAsset.get('id'), 10);
+    const newId = parseInt(newAsset.get('id'), 10);
+    const records = [];
+
+    const pathsByType = {};
+
+    api.assets.list().forEach((asset) => {
+        const type = asset.get('type');
+        if (!pathsByType[type]) {
+            pathsByType[type] = api.schema.assets.getFieldsOfType(type, 'asset');
+        }
+
+        // for models we also need to update meta.userMapping
+        // if any materials change
+        let modelUserMapping = null;
+
+        // get paths and add i18n as well
+        const paths = pathsByType[type].concat(['i18n.*']);
+        paths.forEach((path) => {
+            utils.expandPath(asset, path, (asset, path) => {
+                const value = asset.get(path);
+                if (Array.isArray(value)) {
+                    if (!value.includes(oldId)) {
+                        return;
+                    }
+                } else if (value !== oldId) {
+                    return;
+                }
+
+                // remember previous values
+                records.push({
+                    obj: asset,
+                    path: path,
+                    value: value
+                });
+
+                const history = asset.history.enabled;
+                asset.history.enabled = false;
+                if (Array.isArray(value)) {
+                    asset.set(path, value.map((id) => {
+                        return oldId === id ? newId : id;
+                    }));
+                } else {
+                    asset.set(path, newId);
+                }
+                asset.history.enabled = history;
+
+                if (type === 'model') {
+                    const match = path.match(REGEX_MODEL_DATA_MAPPING);
+                    if (match) {
+                        modelUserMapping = modelUserMapping || {};
+                        modelUserMapping[match[1]] = true;
+                    }
+                }
+            });
+        });
+
+        if (modelUserMapping) {
+            const history = asset.history.enabled;
+            asset.history.enabled = false;
+
+            if (!asset.get('meta')) {
+                records.push({
+                    obj: asset,
+                    path: 'meta',
+                    value: {}
+                });
+
+                asset.set('meta', {});
+            } else {
+                records.push({
+                    obj: asset,
+                    path: 'meta.userMapping',
+                    value: asset.has('meta.userMapping') ? asset.get('meta.userMapping') : undefined
+                });
+            }
+
+            asset.set('meta.userMapping', modelUserMapping);
+
+            asset.history.enabled = history;
+        }
+    });
+
+    return records;
+}
+
+function replace(oldAsset, newAsset, options) {
+    options = options || {};
+    if (options.history === undefined) {
+        options.history = true;
+    }
+
+    let records = [];
+
+    if (api.entities && api.entities.root) {
+        records = records.concat(replaceEntityRefs(oldAsset, newAsset, options));
+    }
+    records = records.concat(replaceAssetRefs(oldAsset, newAsset, options));
+
+    if (api.history && options.history) {
+        api.history.add({
+            name: 'replace asset references',
+            undo: () => {
+                if (!records) return;
+
+                records.forEach((record) => {
+                    const obj = record.obj.latest();
+                    if (!obj || !obj.has(record.path)) return;
+
+                    const history = obj.history.enabled;
+                    obj.history.enabled = false;
+                    if (record.value === undefined) {
+                        obj.unset(record.path);
+                    } else {
+                        obj.set(record.path, record.value);
+                    }
+                    obj.history.enabled = history;
+                });
+            },
+            redo: () => {
+                records = null;
+
+                if (!oldAsset.latest()) return;
+                if (!newAsset.latest()) return;
+
+                records = replace(oldAsset, newAsset, { history: false });
+            }
+        });
+    }
+
+    return records;
+}
+
+export { replace };

--- a/src/entities/references.js
+++ b/src/entities/references.js
@@ -1,18 +1,9 @@
 import { globals as api } from '../globals';
+import { utils } from '../utils';
 
-const entityFieldsCache = {};
+const fieldsCache = {};
 
-
-/**
- * Return a map of all entity reference properties in the graph. This will
- * include references of the entity and also references of its children
- *
- * @private
- * @typedef {import("../entity").Entity} Entity
- * @param {Entity} entity - The entity
- * @returns {object} The entity references
- */
-function findEntityReferencesInComponents(entity) {
+function findReferencesInComponents(entity, refType) {
     const result = {};
 
     function addReference(entity, path, value) {
@@ -41,7 +32,7 @@ function findEntityReferencesInComponents(entity) {
         }
     }
 
-    function handleEntityReference(entity, path) {
+    function handleReference(entity, path) {
         const value = entity.get(path);
         if (!value) return;
         if (Array.isArray(value)) {
@@ -58,14 +49,18 @@ function findEntityReferencesInComponents(entity) {
     entity.depthFirst((entity) => {
         const componentNames = Object.keys(entity.get('components') || {});
         componentNames.forEach((component) => {
-            if (!entityFieldsCache[component]) {
-                entityFieldsCache[component] = api.schema.components.getFieldsOfType(component, 'entity');
+            if (!fieldsCache[refType]) {
+                fieldsCache[refType] = {};
+            }
+            if (!fieldsCache[refType][component]) {
+                fieldsCache[refType][component] = api.schema.components.getFieldsOfType(component, refType);
             }
 
-            entityFieldsCache[component].forEach((field) => {
-                // TODO: handle paths that contain '*'
-                const path = `components.${component}.${field}`;
-                handleEntityReference(entity, path);
+            fieldsCache[refType][component].forEach((field) => {
+                // expand path will handle paths that contain '*'
+                utils.expandPath(entity, `components.${component}.${field}`, (entity, path) => {
+                    handleReference(entity, path);
+                });
             });
 
             // get script attributes
@@ -93,19 +88,19 @@ function findEntityReferencesInComponents(entity) {
                             if (attributeDef.array) {
                                 for (let i = 0; i < attributeValue.length; i++) {
                                     attributeDef.schema.forEach((field) => {
-                                        if (field.type !== 'entity') return;
+                                        if (field.type !== refType) return;
 
                                         handleScriptAttribute(entity, `${componentAttributePath}.${i}.${field.name}`, field, attributeValue[i]?.[field.name]);
                                     });
                                 }
                             } else {
                                 attributeDef.schema.forEach((field) => {
-                                    if (field.type !== 'entity') return;
+                                    if (field.type !== refType) return;
 
                                     handleScriptAttribute(entity, `${componentAttributePath}.${field.name}`, field, attributeValue[field.name]);
                                 });
                             }
-                        } else if (attributeDef.type === 'entity') {
+                        } else if (attributeDef.type === refType) {
                             handleScriptAttribute(entity, componentAttributePath, attributeDef, attributeValue);
                         }
                     }
@@ -115,28 +110,55 @@ function findEntityReferencesInComponents(entity) {
     });
 
     return result;
+
+
+}
+
+
+/**
+ * Return a map of all entity reference properties in the graph. This will
+ * include references of the entity and also references of its children
+ *
+ * @private
+ * @typedef {import("../entity").Entity} Entity
+ * @param {Entity} entity - The entity
+ * @returns {object} The entity references
+ */
+function findEntityReferencesInComponents(entity) {
+    return findReferencesInComponents(entity, 'entity');
 }
 
 /**
- * Updates entity references to the old entity to point to the new entity
+ * Return a map of all asset reference properties in the graph.
  *
  * @private
- * @param {object} entityReferences - A map of entity references
- * @param {string} oldValue - The entity id that we want to replace
- * @param {string} newValue - The new entity id that we want our references to point to
+ * @typedef {import("../entity").Entity} Entity
+ * @param {Entity} entity - The entity
+ * @returns {object} The asset references
  */
-function updateReferences(entityReferences, oldValue, newValue) {
-    const referencesToEntity = entityReferences[oldValue];
+function findAssetReferencesInComponents(entity) {
+    return findReferencesInComponents(entity, 'asset');
+}
+
+/**
+ * Updates references to the old value to point to the new value
+ *
+ * @private
+ * @param {object} references - A map of references that we got
+ * from findEntityReferencesInComponents or findAssetReferencesInComponents.
+ * @param {string|number} oldValue - The value that we want to replace
+ * @param {string|number} newValue - The value that we want our references to point to
+ */
+function updateReferences(references, oldValue, newValue) {
+    const referencesToEntity = references[oldValue];
     if (!referencesToEntity) return;
 
     referencesToEntity.forEach((reference) => {
         const entity = api.entities.get(reference.entityId);
-        if (entity) {
+        if (entity && entity.has(reference.path)) {
             const history = entity.history.enabled;
             entity.history.enabled = false;
-            if (entity.has(reference.path)) {
-                entity.set(reference.path, newValue);
-            }
+            entity.set(reference.path, newValue);
             entity.history.enabled = history;
         }
     });
@@ -145,5 +167,6 @@ function updateReferences(entityReferences, oldValue, newValue) {
 
 export {
     findEntityReferencesInComponents,
+    findAssetReferencesInComponents,
     updateReferences
 };

--- a/src/globals.js
+++ b/src/globals.js
@@ -46,6 +46,13 @@ class globals {
     static entities;
 
     /**
+     * The settings API
+     *
+     * @type {import("./settings").Settings}
+     */
+    static settings;
+
+    /**
      * The messenger API
      *
      * @type {import("./messenger").Messenger}

--- a/src/realtime/asset.js
+++ b/src/realtime/asset.js
@@ -44,7 +44,7 @@ class RealtimeAsset extends Events {
     }
 
     /**
-     * Unloads scene from sharedb and unsubscribes from changes.
+     * Unloads asset from sharedb and unsubscribes from changes.
      */
     unload() {
         if (!this._document) return;

--- a/src/schema/assets.js
+++ b/src/schema/assets.js
@@ -40,6 +40,48 @@ class AssetsSchema {
 
         return result;
     }
+
+    /**
+     * Gets a list of fields of a particular type for an asset type
+     *
+     * @param {string} assetType - The type of the asset.
+     * @param {string} type - The desired type
+     * @returns {string[]} A list of fields
+     * @example
+     * ```javascript
+     * const materialAssetPaths = editor.schema.assets.getFieldsOfType('material', 'asset');
+     * ```
+     */
+    getFieldsOfType(assetType, type) {
+        const result = [];
+
+        const recurse = (schemaField, path, prefix = '') => {
+            if (!schemaField) return;
+
+            if (schemaField.$editorType === type || schemaField.$editorType === 'array:' + type) {
+                result.push(prefix + path);
+                return;
+            }
+
+            for (const field in schemaField) {
+                if (field.startsWith('$')) continue;
+
+                const p = (path ? path + '.' : '') + field;
+                const fieldType = this._schemaApi.getType(schemaField[field]);
+                if (fieldType === type || fieldType === 'array:' + type) {
+                    result.push(prefix + p);
+                } else if (fieldType === 'object' && schemaField[field].$of) {
+                    recurse(schemaField[field].$of, p + '.*', prefix);
+                } else if (fieldType === 'array:object' && Array.isArray(schemaField[field].$type)) {
+                    recurse(schemaField[field].$type[0], p + '.*', prefix);
+                }
+            }
+        };
+
+        recurse(this._schema[assetType + 'Data'], '', 'data.');
+
+        return result;
+    }
 }
 
 export { AssetsSchema };

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,0 +1,27 @@
+import { Events } from '@playcanvas/observer';
+import { SceneSettings } from './settings/scene';
+
+/**
+ * The settings editor API
+ */
+class Settings extends Events {
+    /**
+     * Creates new API instance
+     */
+    constructor() {
+        super();
+
+        this._sceneSettings = new SceneSettings();
+    }
+
+    /**
+     * Gets the settings for the currently loaded scene.
+     *
+     * @type {SceneSettings}
+     */
+    get scene() {
+        return this._sceneSettings;
+    }
+}
+
+export { Settings };

--- a/src/settings/scene.js
+++ b/src/settings/scene.js
@@ -1,0 +1,128 @@
+import { Events, Observer, ObserverHistory } from '@playcanvas/observer';
+import { globals as api } from '../globals';
+
+/**
+ * Represents the settings for the currently loaded scene.
+ * For a list of properties see [here](SceneSettingsProperties.md).
+ */
+class SceneSettings extends Events {
+    /**
+     * Creates new instance of the API
+     *
+     * @private
+     */
+    constructor() {
+        super();
+
+        this._initializeObserver();
+
+        if (api.realtime) {
+            api.realtime.on('load:scene', this._onLoadScene.bind(this));
+        }
+    }
+
+    /**
+     * Initialize internal observer and history.
+     *
+     * @private
+     */
+    _initializeObserver() {
+        if (!this._observer) {
+            this._observer = new Observer();
+        }
+
+        if (this._history) {
+            this._history.destroy();
+        }
+
+        this._history = new ObserverHistory({
+            item: this._observer,
+            prefix: 'settings',
+            history: api.history
+        });
+    }
+
+    /**
+     * Called when a scene is loaded.
+     *
+     * @private
+     * @typedef {import("../realtime/scene").RealtimeScene} RealtimeScene
+     * @param {RealtimeScene} scene - The loaded scene
+     */
+    _onLoadScene(scene) {
+        this._initializeObserver();
+
+        this._history.enabled = false;
+        this._observer.patch(scene.data.settings);
+        this._history.enabled = true;
+
+        this.emit('load');
+    }
+
+    /**
+     * Checks if path exists. See [here](SceneSettingsProperties.md) for a list of properties.
+     *
+     * @param {string} path - The path
+     * @returns {boolean} True if path exists
+     *
+     * @example
+     * ```javascript
+     * console.log(editor.settings.scene.has('render.fog'));
+     * ```
+     */
+    has(path) {
+        return this._observer.has(path);
+    }
+
+    /**
+     * Gets value at path. See [here](SceneSettingsProperties.md) for a list of properties.
+     *
+     * @param {string} path - The path
+     * @returns {any} The value
+     * @example
+     * ```javascript
+     * console.log(editor.settings.scene.get('render.fog'));
+     * ```
+     */
+    get(path) {
+        return this._observer.get(path);
+    }
+
+    /**
+     * Sets value at path. See [here](SceneSettingsProperties.md) for a list of properties.
+     *
+     * @param {string} path - The path
+     * @param {any} value - The value
+     * @returns {boolean} Whether the value was set
+     * @example
+     * ```javascript
+     * editor.settings.scene.set('render.fog', 'none');
+     * ```
+     */
+    set(path, value) {
+        return this._observer.set(path, value);
+    }
+
+    /**
+     * Returns JSON representation of scene settings data
+     *
+     * @returns {object} - The data
+     * ```javascript
+     * console.log(editor.settings.scene.json());
+     * ```
+     */
+    json() {
+        return this._observer.json();
+    }
+
+    /**
+     * Gets the history object for this entity
+     *
+     * @type {ObserverHistory}
+     */
+    get history() {
+        return this._history;
+    }
+}
+
+export { SceneSettings };

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,6 +29,93 @@ class utils {
         }
         return obj;
     }
+
+    static expandPath(obj, path, fn) {
+        function forEachPathInData(pathParts, pathSoFar, startIndex, data, fn) {
+            if (!data) return;
+
+            function process(item, key) {
+                let current = item;
+                let p = (pathSoFar ? pathSoFar + '.' : '') + key;
+                for (let i = startIndex; i < pathParts.length; i++) {
+                    // if we found another star recurse
+                    if (pathParts[i] === '*') {
+                        forEachPathInData(pathParts, p, i + 1, current, fn);
+                        return;
+                    }
+
+                    // keep getting deeper into the object as long as each path part exists
+                    if (!current.hasOwnProperty(pathParts[i])) {
+                        return;
+                    }
+
+                    current = current[pathParts[i]];
+
+                    // if we found a null entry then stop unless this is the
+                    // final path part which means we ended up at the end of the path
+                    // which is fine
+                    if (!current && i < pathParts.length - 1) {
+                        return;
+                    }
+
+                    p += '.' + pathParts[i];
+                }
+
+                // call callback with the path we've found so far
+                fn(obj, p);
+            }
+
+            if (Array.isArray(data)) {
+                // if data is an array then process all of its array items
+                data.forEach((item, index) => {
+                    process(item, index);
+                });
+            } else {
+                // if data is a JSON object then process all of its keys
+                const keys = Object.keys(data);
+                keys.forEach((key) => {
+                    process(data[key], key);
+                });
+            }
+        }
+
+        // if this is a simple path without a star
+        // then just early out
+        if (!path.includes('*')) {
+            if (obj.has(path)) {
+                fn(obj, path);
+            }
+
+            return;
+        }
+
+        // paths with stars need to be broken up
+        // and processed differently. When a star is encountered
+        // we have to process all of the entries under the star
+        const parts = path.split('.');
+        if (parts[0] === '*') {
+            // handle special case when first part of path is a star
+            forEachPathInData(parts, '', 1, obj.json(), fn);
+            return;
+        }
+
+        // find path until first star
+        let firstPartialPath = parts[0];
+        let i;
+        for (i = 1; i < parts.length; i++) {
+            if (parts[i] === '*') break;
+            firstPartialPath += '.' + parts[i];
+        }
+
+        if (!obj.has(firstPartialPath)) return;
+
+        // get json just before first star
+        const json = obj.get(firstPartialPath);
+        if (!json) return;
+
+        // start breaking down each path
+        forEachPathInData(parts, firstPartialPath, i + 1, json, fn);
+    }
 }
 
 export { utils };

--- a/test/api/test-asset.js
+++ b/test/api/test-asset.js
@@ -9,6 +9,8 @@ describe('Asset API tests', function () {
         api.globals.history = null;
         api.globals.assets = null;
         api.globals.schema = null;
+        api.globals.realtime = null;
+        api.globals.settings = null;
     });
 
     it('replace replaces component references', function () {
@@ -242,5 +244,36 @@ describe('Asset API tests', function () {
 
         expect(model.get('meta')).to.deep.equal({ userMapping: { '0': true } });
         expect(model2.get('meta')).to.deep.equal({ userMapping: { '0': true } });
+    });
+
+    it('replace replaces skybox in scene settings', function () {
+        api.globals.realtime = new api.Realtime();
+        api.globals.settings = new api.Settings();
+        api.globals.schema = new api.Schema(schema);
+
+        const asset = new api.Asset({ id: 1, type: 'cubemap' });
+        api.globals.assets.add(asset);
+
+        const asset2 = new api.Asset({ id: 2, type: 'cubemap' });
+        api.globals.assets.add(asset2);
+
+        api.globals.settings.scene.set('render.skybox', 1);
+
+        asset.replace(asset2);
+
+        expect(api.globals.settings.scene.get('render.skybox')).to.equal(2);
+
+        // undo
+        api.globals.history.undo();
+        expect(api.globals.settings.scene.get('render.skybox')).to.equal(1);
+
+        // redo
+        api.globals.history.redo();
+        expect(api.globals.settings.scene.get('render.skybox')).to.equal(2);
+
+        // check unrelated skybox is not updated
+        api.globals.settings.scene.set('render.skybox', 3);
+        asset.replace(asset2);
+        expect(api.globals.settings.scene.get('render.skybox')).to.equal(3);
     });
 });

--- a/test/api/test-asset.js
+++ b/test/api/test-asset.js
@@ -1,0 +1,246 @@
+describe('Asset API tests', function () {
+    beforeEach(function () {
+        api.globals.assets = new api.Assets();
+        api.globals.history = new api.History();
+    });
+
+    afterEach(function () {
+        api.globals.entities = null;
+        api.globals.history = null;
+        api.globals.assets = null;
+        api.globals.schema = null;
+    });
+
+    it('replace replaces component references', function () {
+        api.globals.entities = new api.Entities();
+        api.globals.schema = new api.Schema(schema);
+
+        const asset = new api.Asset({ id: 1, type: 'material' });
+        api.globals.assets.add(asset);
+
+        const asset2 = new api.Asset({ id: 2, type: 'material' });
+        api.globals.assets.add(asset2);
+
+        const e = api.globals.entities.create();
+        e.addComponent('testcomponent', {
+            assetRef: 1,
+            assetArrayRef: [1],
+            nestedAssetRef: {
+                'key': {
+                    asset: 1
+                }
+            }
+        });
+
+        asset.replace(asset2);
+
+        expect(e.get('components.testcomponent.assetRef')).to.equal(2);
+        expect(e.get('components.testcomponent.assetArrayRef')).to.deep.equal([2]);
+        expect(e.get('components.testcomponent.nestedAssetRef.key.asset')).to.equal(2);
+
+        // undo
+        api.globals.history.undo();
+
+        expect(e.get('components.testcomponent.assetRef')).to.equal(1);
+        expect(e.get('components.testcomponent.assetArrayRef')).to.deep.equal([1]);
+        expect(e.get('components.testcomponent.nestedAssetRef.key.asset')).to.equal(1);
+
+        // redo
+        api.globals.history.redo();
+
+        expect(e.get('components.testcomponent.assetRef')).to.equal(2);
+        expect(e.get('components.testcomponent.assetArrayRef')).to.deep.equal([2]);
+        expect(e.get('components.testcomponent.nestedAssetRef.key.asset')).to.equal(2);
+    });
+
+    it('replace replaces asset references', function () {
+        api.globals.schema = new api.Schema(schema);
+
+        const asset = new api.Asset({ id: 1, type: 'test' });
+        api.globals.assets.add(asset);
+
+        asset.set('i18n', {
+            en: 1
+        });
+
+        asset.set('data', {
+            assetRef: 1,
+            assetArrayRef: [1, 3],
+            nestedAssetRef: {
+                'key': {
+                    asset: 1
+                },
+                'key2': {
+                    asset: 3
+                }
+            }
+        });
+
+        const asset2 = new api.Asset({ id: 2, type: 'material' });
+        api.globals.assets.add(asset2);
+
+        asset.replace(asset2);
+
+        expect(asset.get('data.assetRef')).to.equal(2);
+        expect(asset.get('data.assetArrayRef')).to.deep.equal([2, 3]);
+        expect(asset.get('data.nestedAssetRef.key.asset')).to.equal(2);
+        expect(asset.get('i18n.en')).to.equal(2);
+
+        // undo
+        api.globals.history.undo();
+        expect(asset.get('data.assetRef')).to.equal(1);
+        expect(asset.get('data.assetArrayRef')).to.deep.equal([1, 3]);
+        expect(asset.get('data.nestedAssetRef.key.asset')).to.equal(1);
+        expect(asset.get('i18n.en')).to.equal(1);
+
+        // redo
+        api.globals.history.redo();
+        expect(asset.get('data.assetRef')).to.equal(2);
+        expect(asset.get('data.assetArrayRef')).to.deep.equal([2, 3]);
+        expect(asset.get('data.nestedAssetRef.key.asset')).to.equal(2);
+        expect(asset.get('i18n.en')).to.equal(2);
+    });
+
+    it('replace replaces script attributes', function () {
+        api.globals.entities = new api.Entities();
+        api.globals.schema = new api.Schema(schema);
+
+        const asset = new api.Asset({ id: 1, type: 'material' });
+        api.globals.assets.add(asset);
+
+        const asset2 = new api.Asset({ id: 2, type: 'material' });
+        api.globals.assets.add(asset2);
+
+        const script = new api.Asset({ id: 3, type: 'script' });
+        api.globals.assets.add(script);
+        script.set('data', {
+            scripts: {
+                test: {
+                    attributes: {
+                        assetRef: {
+                            type: 'asset'
+                        },
+                        assetArrayRef: {
+                            type: 'asset',
+                            array: true
+                        },
+                        json: {
+                            type: 'json',
+                            schema: [{
+                                name: 'assetRef',
+                                type: 'asset'
+                            }, {
+                                name: 'assetArrayRef',
+                                type: 'asset',
+                                array: true
+                            }]
+                        },
+                        jsonArray: {
+                            type: 'json',
+                            array: true,
+                            schema: [{
+                                name: 'assetRef',
+                                type: 'asset'
+                            }, {
+                                name: 'assetArrayRef',
+                                type: 'asset',
+                                array: true
+                            }]
+                        }
+                    }
+                }
+            }
+        });
+
+        const e = api.globals.entities.create();
+        e.addComponent('script', {
+            order: ['test'],
+            scripts: {
+                test: {
+                    attributes: {
+                        assetRef: 1,
+                        assetArrayRef: [1],
+                        json: {
+                            assetRef: 1,
+                            assetArrayRef: [1]
+                        },
+                        jsonArray: [{
+                            assetRef: 1,
+                            assetArrayRef: [1]
+                        }]
+                    }
+                }
+            }
+        });
+
+        asset.replace(asset2);
+
+        expect(e.get('components.script.scripts.test.attributes.assetRef')).to.equal(2);
+        expect(e.get('components.script.scripts.test.attributes.assetArrayRef')).to.deep.equal([2]);
+        expect(e.get('components.script.scripts.test.attributes.json.assetRef')).to.equal(2);
+        expect(e.get('components.script.scripts.test.attributes.json.assetArrayRef')).to.deep.equal([2]);
+        expect(e.get('components.script.scripts.test.attributes.jsonArray.0.assetRef')).to.equal(2);
+        expect(e.get('components.script.scripts.test.attributes.jsonArray.0.assetArrayRef')).to.deep.equal([2]);
+
+        // undo
+        api.globals.history.undo();
+        expect(e.get('components.script.scripts.test.attributes.assetRef')).to.equal(1);
+        expect(e.get('components.script.scripts.test.attributes.assetArrayRef')).to.deep.equal([1]);
+        expect(e.get('components.script.scripts.test.attributes.json.assetRef')).to.equal(1);
+        expect(e.get('components.script.scripts.test.attributes.json.assetArrayRef')).to.deep.equal([1]);
+        expect(e.get('components.script.scripts.test.attributes.jsonArray.0.assetRef')).to.equal(1);
+        expect(e.get('components.script.scripts.test.attributes.jsonArray.0.assetArrayRef')).to.deep.equal([1]);
+
+        // redo
+        api.globals.history.redo();
+        expect(e.get('components.script.scripts.test.attributes.assetRef')).to.equal(2);
+        expect(e.get('components.script.scripts.test.attributes.assetArrayRef')).to.deep.equal([2]);
+        expect(e.get('components.script.scripts.test.attributes.json.assetRef')).to.equal(2);
+        expect(e.get('components.script.scripts.test.attributes.json.assetArrayRef')).to.deep.equal([2]);
+        expect(e.get('components.script.scripts.test.attributes.jsonArray.0.assetRef')).to.equal(2);
+        expect(e.get('components.script.scripts.test.attributes.jsonArray.0.assetArrayRef')).to.deep.equal([2]);
+    });
+
+    it('replace model mapping updates meta.userMapping', function () {
+        api.globals.schema = new api.Schema(schema);
+
+        const model = new api.Asset({ id: 1, type: 'model' });
+        api.globals.assets.add(model);
+
+        model.set('data', {
+            mapping: [{
+                material: 1
+            }]
+        });
+
+        const model2 = new api.Asset({ id: 3, type: 'model' });
+        api.globals.assets.add(model2);
+
+        model2.set('data', {
+            mapping: [{
+                material: 1
+            }]
+        });
+        model2.set('meta', {});
+
+        const asset2 = new api.Asset({ id: 2, type: 'material' });
+        api.globals.assets.add(asset2);
+
+        model.replace(asset2);
+
+        expect(model.get('meta')).to.deep.equal({ userMapping: { '0': true } });
+        expect(model2.get('meta')).to.deep.equal({ userMapping: { '0': true } });
+
+        // undo
+        api.globals.history.undo();
+
+        expect(model.get('meta')).to.deep.equal({});
+        expect(model2.get('meta')).to.deep.equal({});
+
+        // redo
+        api.globals.history.redo();
+
+        expect(model.get('meta')).to.deep.equal({ userMapping: { '0': true } });
+        expect(model2.get('meta')).to.deep.equal({ userMapping: { '0': true } });
+    });
+});

--- a/test/api/test-utils.js
+++ b/test/api/test-utils.js
@@ -1,0 +1,143 @@
+describe('utils tests', function () {
+    it('expandPath is called for paths with no stars', function () {
+        const obj = new observer.Observer({
+            position: [1, 2, 3],
+            components: {
+                test: {
+                    field: 1,
+                    field2: null
+                },
+                arr: [{
+                    data: {
+                        field: 1
+                    }
+                }]
+            }
+        });
+        const called = [];
+        api.utils.expandPath(obj, 'position', (obj, path) => {
+            called.push([obj, path]);
+        });
+        api.utils.expandPath(obj, 'components.test.field', (obj, path) => {
+            called.push([obj, path]);
+        });
+        api.utils.expandPath(obj, 'components.test.field2', (obj, path) => {
+            called.push([obj, path]);
+        });
+        api.utils.expandPath(obj, 'components.arr.0.data.field', (obj, path) => {
+            called.push([obj, path]);
+        });
+
+        expect(called).to.deep.equal([
+            [obj, 'position'],
+            [obj, 'components.test.field'],
+            [obj, 'components.test.field2'],
+            [obj, 'components.arr.0.data.field']
+        ]);
+    });
+
+    it('expandPath is called for paths with stars', function () {
+        const obj = new observer.Observer({
+            components: {
+                test: {
+                    field: 1,
+                    field2: null
+                },
+                arr: [{
+                    data: {
+                        field: 1
+                    },
+                    data2: {
+                        field: 1
+                    }
+                }, {
+                    data: {
+                        field: null
+                    },
+                    data2: {
+                        field: null
+                    }
+                }]
+            }
+        });
+        const called = [];
+        api.utils.expandPath(obj, '*', (obj, path) => {
+            called.push([obj, path]);
+        });
+        api.utils.expandPath(obj, 'components.test.*', (obj, path) => {
+            called.push([obj, path]);
+        });
+        api.utils.expandPath(obj, 'components.arr.*', (obj, path) => {
+            called.push([obj, path]);
+        });
+        api.utils.expandPath(obj, 'components.arr.*.data.field', (obj, path) => {
+            called.push([obj, path]);
+        });
+        api.utils.expandPath(obj, 'components.arr.*.*.field', (obj, path) => {
+            called.push([obj, path]);
+        });
+
+        expect(called).to.deep.equal([
+            [obj, 'components'],
+
+            [obj, 'components.test.field'],
+            [obj, 'components.test.field2'],
+
+            [obj, 'components.arr.0'],
+            [obj, 'components.arr.1'],
+
+            [obj, 'components.arr.0.data.field'],
+            [obj, 'components.arr.1.data.field'],
+
+            [obj, 'components.arr.0.data.field'],
+            [obj, 'components.arr.0.data2.field'],
+            [obj, 'components.arr.1.data.field'],
+            [obj, 'components.arr.1.data2.field']
+        ]);
+    });
+
+    it('expandPath is only called for paths that exist', function () {
+        const obj = new observer.Observer({
+            components: {
+                test: {
+                    field: 1,
+                    field2: null
+                },
+                arr: [{
+                    data: {
+                        field: 1
+                    },
+                    data2: {
+                        field2: 1
+                    }
+                }, {
+                    data: {
+                        field: null
+                    },
+                    data2: {
+                        field2: null
+                    }
+                }]
+            }
+        });
+        const called = [];
+        api.utils.expandPath(obj, 'components.*.field', (obj, path) => {
+            called.push(path);
+        });
+        api.utils.expandPath(obj, 'components.arr.2', (obj, path) => {
+            called.push(path);
+        });
+        api.utils.expandPath(obj, 'components.arr.2.data.field', (obj, path) => {
+            called.push(path);
+        });
+        api.utils.expandPath(obj, 'components.arr.*.*.field2', (obj, path) => {
+            called.push(path);
+        });
+
+        expect(called).to.deep.equal([
+            'components.test.field',
+            'components.arr.0.data2.field2',
+            'components.arr.1.data2.field2'
+        ]);
+    });
+});

--- a/test/lib/schema.js
+++ b/test/lib/schema.js
@@ -67,14 +67,46 @@ window.schema = {
     },
     animstategraphData: {
         testData: {
-            type: 'number',
+            $type: 'number',
             $default: 0
         }
     },
     materialData: {
         diffuse: {
-            type: ["number"],
+            $type: ["number"],
             $default: [0, 0, 0]
+        }
+    },
+    modelData: {
+        mapping: {
+            $type: [{
+                material: {
+                    $type: 'number',
+                    $editorType: 'asset'
+                }
+            }]
+        }
+    },
+    testData: {
+        assetRef: {
+            $type: 'number',
+            $editorType: 'asset',
+            $default: null
+        },
+        assetArrayRef: {
+            $type: ['number'],
+            $editorType: 'array:asset',
+            $default: []
+        },
+        nestedAssetRef: {
+            $type: 'map',
+            $of: {
+                asset: {
+                    $type: 'number',
+                    $editorType: 'asset',
+                    $default: null
+                }
+            }
         }
     }
 };


### PR DESCRIPTION
This PR adds functionality to replace references to an asset with another asset. It also adds API for scene settings which is needed in part for the replacing mechanism which has to update the scene's skybox when a cubemap is replaced.