### PR TITLE
Fix duplicate nested template

### DIFF
--- a/docs/classes/Asset.md
+++ b/docs/classes/Asset.md
@@ -60,7 +60,7 @@ The file URL
 
 #### Defined in
 
-[src/asset.js:307](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L307)
+[src/asset.js:307](https://github.com/playcanvas/editor-api/blob/1e69a27/src/asset.js#L307)
 
 ___
 
@@ -84,7 +84,7 @@ True if path exists
 
 #### Defined in
 
-[src/asset.js:111](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L111)
+[src/asset.js:111](https://github.com/playcanvas/editor-api/blob/1e69a27/src/asset.js#L111)
 
 ___
 
@@ -108,7 +108,7 @@ The value
 
 #### Defined in
 
-[src/asset.js:121](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L121)
+[src/asset.js:121](https://github.com/playcanvas/editor-api/blob/1e69a27/src/asset.js#L121)
 
 ___
 
@@ -133,7 +133,7 @@ Whether the value was set
 
 #### Defined in
 
-[src/asset.js:132](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L132)
+[src/asset.js:132](https://github.com/playcanvas/editor-api/blob/1e69a27/src/asset.js#L132)
 
 ___
 
@@ -157,7 +157,7 @@ Whether the value was unset
 
 #### Defined in
 
-[src/asset.js:142](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L142)
+[src/asset.js:142](https://github.com/playcanvas/editor-api/blob/1e69a27/src/asset.js#L142)
 
 ___
 
@@ -183,7 +183,7 @@ Whether the value was inserted
 
 #### Defined in
 
-[src/asset.js:154](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L154)
+[src/asset.js:154](https://github.com/playcanvas/editor-api/blob/1e69a27/src/asset.js#L154)
 
 ___
 
@@ -208,7 +208,7 @@ Whether the value was removed
 
 #### Defined in
 
-[src/asset.js:165](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L165)
+[src/asset.js:165](https://github.com/playcanvas/editor-api/blob/1e69a27/src/asset.js#L165)
 
 ___
 
@@ -226,7 +226,7 @@ Returns JSON representation of entity data
 
 #### Defined in
 
-[src/asset.js:174](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L174)
+[src/asset.js:174](https://github.com/playcanvas/editor-api/blob/1e69a27/src/asset.js#L174)
 
 ___
 
@@ -244,7 +244,7 @@ The asset
 
 #### Defined in
 
-[src/asset.js:183](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L183)
+[src/asset.js:183](https://github.com/playcanvas/editor-api/blob/1e69a27/src/asset.js#L183)
 
 ___
 
@@ -260,7 +260,7 @@ Loads asset from the server without subscribing to realtime changes.
 
 #### Defined in
 
-[src/asset.js:190](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L190)
+[src/asset.js:190](https://github.com/playcanvas/editor-api/blob/1e69a27/src/asset.js#L190)
 
 ___
 
@@ -276,7 +276,7 @@ Loads the asset's data from sharedb and subscribes to changes
 
 #### Defined in
 
-[src/asset.js:215](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L215)
+[src/asset.js:215](https://github.com/playcanvas/editor-api/blob/1e69a27/src/asset.js#L215)
 
 ___
 
@@ -292,7 +292,7 @@ Deletes this asset
 
 #### Defined in
 
-[src/asset.js:258](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L258)
+[src/asset.js:258](https://github.com/playcanvas/editor-api/blob/1e69a27/src/asset.js#L258)
 
 ___
 
@@ -322,7 +322,7 @@ The new entity.
 
 #### Defined in
 
-[src/asset.js:274](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L274)
+[src/asset.js:274](https://github.com/playcanvas/editor-api/blob/1e69a27/src/asset.js#L274)
 
 ___
 
@@ -347,7 +347,7 @@ references to the new asset specified.
 
 #### Defined in
 
-[src/asset.js:287](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L287)
+[src/asset.js:287](https://github.com/playcanvas/editor-api/blob/1e69a27/src/asset.js#L287)
 
 ## Constructors
 
@@ -369,7 +369,7 @@ Events.constructor
 
 #### Defined in
 
-[src/asset.js:16](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L16)
+[src/asset.js:16](https://github.com/playcanvas/editor-api/blob/1e69a27/src/asset.js#L16)
 
 ## Accessors
 
@@ -385,4 +385,4 @@ Gets observer history for this assset
 
 #### Defined in
 
-[src/asset.js:296](https://github.com/playcanvas/editor-api/blob/a50e91b/src/asset.js#L296)
+[src/asset.js:296](https://github.com/playcanvas/editor-api/blob/1e69a27/src/asset.js#L296)

--- a/docs/classes/Assets.md
+++ b/docs/classes/Assets.md
@@ -78,7 +78,7 @@ Events.constructor
 
 #### Defined in
 
-[src/assets.js:62](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L62)
+[src/assets.js:62](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L62)
 
 ## Public Methods
 
@@ -102,7 +102,7 @@ The asset
 
 #### Defined in
 
-[src/assets.js:154](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L154)
+[src/assets.js:154](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L154)
 
 ___
 
@@ -126,7 +126,7 @@ The asset
 
 #### Defined in
 
-[src/assets.js:165](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L165)
+[src/assets.js:165](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L165)
 
 ___
 
@@ -144,7 +144,7 @@ The assets
 
 #### Defined in
 
-[src/assets.js:175](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L175)
+[src/assets.js:175](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L175)
 
 ___
 
@@ -168,7 +168,7 @@ The assets
 
 #### Defined in
 
-[src/assets.js:186](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L186)
+[src/assets.js:186](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L186)
 
 ___
 
@@ -192,7 +192,7 @@ The assets
 
 #### Defined in
 
-[src/assets.js:313](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L313)
+[src/assets.js:313](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L313)
 
 ___
 
@@ -216,7 +216,7 @@ The asset
 
 #### Defined in
 
-[src/assets.js:325](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L325)
+[src/assets.js:325](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L325)
 
 ___
 
@@ -240,7 +240,7 @@ The script asset
 
 #### Defined in
 
-[src/assets.js:442](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L442)
+[src/assets.js:442](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L442)
 
 ___
 
@@ -269,7 +269,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:506](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L506)
+[src/assets.js:506](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L506)
 
 ___
 
@@ -298,7 +298,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:527](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L527)
+[src/assets.js:527](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L527)
 
 ___
 
@@ -327,7 +327,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:550](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L550)
+[src/assets.js:550](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L550)
 
 ___
 
@@ -359,7 +359,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:576](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L576)
+[src/assets.js:576](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L576)
 
 ___
 
@@ -386,7 +386,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:606](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L606)
+[src/assets.js:606](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L606)
 
 ___
 
@@ -415,7 +415,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:625](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L625)
+[src/assets.js:625](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L625)
 
 ___
 
@@ -444,7 +444,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:647](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L647)
+[src/assets.js:647](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L647)
 
 ___
 
@@ -473,7 +473,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:669](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L669)
+[src/assets.js:669](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L669)
 
 ___
 
@@ -502,7 +502,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:702](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L702)
+[src/assets.js:702](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L702)
 
 ___
 
@@ -529,7 +529,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:734](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L734)
+[src/assets.js:734](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L734)
 
 ___
 
@@ -558,7 +558,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:794](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L794)
+[src/assets.js:794](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L794)
 
 ___
 
@@ -590,7 +590,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:819](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L819)
+[src/assets.js:819](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L819)
 
 ___
 
@@ -619,7 +619,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:846](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L846)
+[src/assets.js:846](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L846)
 
 ___
 
@@ -648,7 +648,7 @@ The new asset
 
 #### Defined in
 
-[src/assets.js:869](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L869)
+[src/assets.js:869](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L869)
 
 ___
 
@@ -670,7 +670,7 @@ Deletes specified assets
 
 #### Defined in
 
-[src/assets.js:895](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L895)
+[src/assets.js:895](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L895)
 
 ___
 
@@ -701,7 +701,7 @@ The new entities
 
 #### Defined in
 
-[src/assets.js:927](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L927)
+[src/assets.js:927](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L927)
 
 ___
 
@@ -725,7 +725,7 @@ Adds asset to the list
 
 #### Defined in
 
-[src/assets.js:220](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L220)
+[src/assets.js:220](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L220)
 
 ___
 
@@ -747,7 +747,7 @@ Removes asset from the list
 
 #### Defined in
 
-[src/assets.js:272](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L272)
+[src/assets.js:272](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L272)
 
 ___
 
@@ -763,7 +763,7 @@ Removes all assets from the list
 
 #### Defined in
 
-[src/assets.js:293](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L293)
+[src/assets.js:293](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L293)
 
 ___
 
@@ -780,7 +780,7 @@ subscribe to realtime changes.
 
 #### Defined in
 
-[src/assets.js:336](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L336)
+[src/assets.js:336](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L336)
 
 ___
 
@@ -797,7 +797,7 @@ and subscribes to changes.
 
 #### Defined in
 
-[src/assets.js:385](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L385)
+[src/assets.js:385](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L385)
 
 ## Accessors
 
@@ -813,7 +813,7 @@ Gets the default callback called when on asset upload succeeds.
 
 #### Defined in
 
-[src/assets.js:936](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L936)
+[src/assets.js:936](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L936)
 
 • `set` **defaultUploadCompletedCallback**(`value`): `void`
 
@@ -832,7 +832,7 @@ The function takes 2 arguments: the upload id, and the new asset.
 
 #### Defined in
 
-[src/assets.js:946](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L946)
+[src/assets.js:946](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L946)
 
 ___
 
@@ -848,7 +848,7 @@ Gets the default callback called when on asset upload progress.
 
 #### Defined in
 
-[src/assets.js:955](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L955)
+[src/assets.js:955](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L955)
 
 • `set` **defaultUploadProgressCallback**(`value`): `void`
 
@@ -867,7 +867,7 @@ The function takes 2 arguments: the upload id and the progress.
 
 #### Defined in
 
-[src/assets.js:965](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L965)
+[src/assets.js:965](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L965)
 
 ___
 
@@ -883,7 +883,7 @@ Gets the default callback called when on asset upload fails.
 
 #### Defined in
 
-[src/assets.js:974](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L974)
+[src/assets.js:974](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L974)
 
 • `set` **defaultUploadErrorCallback**(`value`): `void`
 
@@ -902,7 +902,7 @@ The function takes 2 arguments: the upload id, and the error.
 
 #### Defined in
 
-[src/assets.js:984](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L984)
+[src/assets.js:984](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L984)
 
 ___
 
@@ -918,7 +918,7 @@ Gets the callback which parses script assets.
 
 #### Defined in
 
-[src/assets.js:993](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L993)
+[src/assets.js:993](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L993)
 
 • `set` **parseScriptCallback**(`value`): `void`
 
@@ -939,4 +939,4 @@ a promise with a list of script names when it is done parsing.
 
 #### Defined in
 
-[src/assets.js:1005](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L1005)
+[src/assets.js:1005](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L1005)

--- a/docs/classes/AssetsSchema.md
+++ b/docs/classes/AssetsSchema.md
@@ -31,7 +31,7 @@ Provides methods to access the Assets schema
 
 #### Defined in
 
-[src/schema/assets.js:14](https://github.com/playcanvas/editor-api/blob/a50e91b/src/schema/assets.js#L14)
+[src/schema/assets.js:14](https://github.com/playcanvas/editor-api/blob/1e69a27/src/schema/assets.js#L14)
 
 ## Methods
 
@@ -55,7 +55,7 @@ The default data
 
 #### Defined in
 
-[src/schema/assets.js:25](https://github.com/playcanvas/editor-api/blob/a50e91b/src/schema/assets.js#L25)
+[src/schema/assets.js:25](https://github.com/playcanvas/editor-api/blob/1e69a27/src/schema/assets.js#L25)
 
 ___
 
@@ -85,4 +85,4 @@ A list of fields
 
 #### Defined in
 
-[src/schema/assets.js:55](https://github.com/playcanvas/editor-api/blob/a50e91b/src/schema/assets.js#L55)
+[src/schema/assets.js:55](https://github.com/playcanvas/editor-api/blob/1e69a27/src/schema/assets.js#L55)

--- a/docs/classes/Clipboard.md
+++ b/docs/classes/Clipboard.md
@@ -32,7 +32,7 @@ Constructor
 
 #### Defined in
 
-[src/clipboard.js:15](https://github.com/playcanvas/editor-api/blob/a50e91b/src/clipboard.js#L15)
+[src/clipboard.js:15](https://github.com/playcanvas/editor-api/blob/1e69a27/src/clipboard.js#L15)
 
 ## Accessors
 
@@ -48,7 +48,7 @@ Gets whether the clipboard is empty
 
 #### Defined in
 
-[src/clipboard.js:26](https://github.com/playcanvas/editor-api/blob/a50e91b/src/clipboard.js#L26)
+[src/clipboard.js:26](https://github.com/playcanvas/editor-api/blob/1e69a27/src/clipboard.js#L26)
 
 ___
 
@@ -64,7 +64,7 @@ Gets the value stored in the clipboard.
 
 #### Defined in
 
-[src/clipboard.js:35](https://github.com/playcanvas/editor-api/blob/a50e91b/src/clipboard.js#L35)
+[src/clipboard.js:35](https://github.com/playcanvas/editor-api/blob/1e69a27/src/clipboard.js#L35)
 
 • `set` **value**(`value`): `void`
 
@@ -82,4 +82,4 @@ Sets the value to be stored in the clipboard. Pass null to clear the value from 
 
 #### Defined in
 
-[src/clipboard.js:44](https://github.com/playcanvas/editor-api/blob/a50e91b/src/clipboard.js#L44)
+[src/clipboard.js:44](https://github.com/playcanvas/editor-api/blob/1e69a27/src/clipboard.js#L44)

--- a/docs/classes/ComponentSchema.md
+++ b/docs/classes/ComponentSchema.md
@@ -34,7 +34,7 @@ Creates new instance of API
 
 #### Defined in
 
-[src/schema/components.js:15](https://github.com/playcanvas/editor-api/blob/a50e91b/src/schema/components.js#L15)
+[src/schema/components.js:15](https://github.com/playcanvas/editor-api/blob/1e69a27/src/schema/components.js#L15)
 
 ## Methods
 
@@ -63,7 +63,7 @@ The default data
 
 #### Defined in
 
-[src/schema/components.js:43](https://github.com/playcanvas/editor-api/blob/a50e91b/src/schema/components.js#L43)
+[src/schema/components.js:43](https://github.com/playcanvas/editor-api/blob/1e69a27/src/schema/components.js#L43)
 
 ___
 
@@ -93,7 +93,7 @@ A list of fields
 
 #### Defined in
 
-[src/schema/components.js:69](https://github.com/playcanvas/editor-api/blob/a50e91b/src/schema/components.js#L69)
+[src/schema/components.js:69](https://github.com/playcanvas/editor-api/blob/1e69a27/src/schema/components.js#L69)
 
 ___
 
@@ -111,4 +111,4 @@ The components
 
 #### Defined in
 
-[src/schema/components.js:103](https://github.com/playcanvas/editor-api/blob/a50e91b/src/schema/components.js#L103)
+[src/schema/components.js:103](https://github.com/playcanvas/editor-api/blob/1e69a27/src/schema/components.js#L103)

--- a/docs/classes/Entities.md
+++ b/docs/classes/Entities.md
@@ -54,7 +54,7 @@ Events.constructor
 
 #### Defined in
 
-[src/entities.js:48](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L48)
+[src/entities.js:48](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L48)
 
 ## Public Methods
 
@@ -83,7 +83,7 @@ The entity
 
 #### Defined in
 
-[src/entities.js:68](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L68)
+[src/entities.js:68](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L68)
 
 ___
 
@@ -107,7 +107,7 @@ The entities
 
 #### Defined in
 
-[src/entities.js:83](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L83)
+[src/entities.js:83](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L83)
 
 ___
 
@@ -147,7 +147,7 @@ The new entity
 
 #### Defined in
 
-[src/entities.js:251](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L251)
+[src/entities.js:251](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L251)
 
 ___
 
@@ -176,7 +176,7 @@ await editor.entities.delete([entity1, entity2]);
 
 #### Defined in
 
-[src/entities.js:267](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L267)
+[src/entities.js:267](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L267)
 
 ___
 
@@ -211,7 +211,7 @@ editor.entities.reparent([{
 
 #### Defined in
 
-[src/entities.js:288](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L288)
+[src/entities.js:288](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L288)
 
 ___
 
@@ -242,7 +242,7 @@ The duplicated entities
 
 #### Defined in
 
-[src/entities.js:304](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L304)
+[src/entities.js:304](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L304)
 
 ___
 
@@ -265,7 +265,7 @@ to paste these entities later on.
 
 #### Defined in
 
-[src/entities.js:316](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L316)
+[src/entities.js:316](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L316)
 
 ___
 
@@ -292,7 +292,7 @@ The new entities
 
 #### Defined in
 
-[src/entities.js:329](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L329)
+[src/entities.js:329](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L329)
 
 ___
 
@@ -320,7 +320,7 @@ callback when the entities are added.
 
 #### Defined in
 
-[src/entities.js:344](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L344)
+[src/entities.js:344](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L344)
 
 ___
 
@@ -350,7 +350,7 @@ A promise
 
 #### Defined in
 
-[src/entities.js:362](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L362)
+[src/entities.js:362](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L362)
 
 ___
 
@@ -376,7 +376,7 @@ a single history action.
 
 #### Defined in
 
-[src/entities.js:375](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L375)
+[src/entities.js:375](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L375)
 
 ___
 
@@ -400,7 +400,7 @@ Adds entity to list
 
 #### Defined in
 
-[src/entities.js:93](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L93)
+[src/entities.js:93](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L93)
 
 ___
 
@@ -422,7 +422,7 @@ Called when an entity is added from the server
 
 #### Defined in
 
-[src/entities.js:121](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L121)
+[src/entities.js:121](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L121)
 
 ___
 
@@ -445,7 +445,7 @@ Removes entity from the list
 
 #### Defined in
 
-[src/entities.js:136](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L136)
+[src/entities.js:136](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L136)
 
 ___
 
@@ -467,7 +467,7 @@ Called when an entity is removed from the server
 
 #### Defined in
 
-[src/entities.js:185](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L185)
+[src/entities.js:185](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L185)
 
 ___
 
@@ -483,4 +483,4 @@ Removes all entities from the list
 
 #### Defined in
 
-[src/entities.js:207](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L207)
+[src/entities.js:207](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L207)

--- a/docs/classes/Entity.md
+++ b/docs/classes/Entity.md
@@ -68,7 +68,7 @@ Events.constructor
 
 #### Defined in
 
-[src/entity.js:17](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L17)
+[src/entity.js:17](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entity.js#L17)
 
 ## Public Methods
 
@@ -97,7 +97,7 @@ True if path exists
 
 #### Defined in
 
-[src/entity.js:88](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L88)
+[src/entity.js:88](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entity.js#L88)
 
 ___
 
@@ -126,7 +126,7 @@ The value
 
 #### Defined in
 
-[src/entity.js:102](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L102)
+[src/entity.js:102](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entity.js#L102)
 
 ___
 
@@ -156,7 +156,7 @@ Whether the value was set
 
 #### Defined in
 
-[src/entity.js:117](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L117)
+[src/entity.js:117](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entity.js#L117)
 
 ___
 
@@ -185,7 +185,7 @@ Whether the value was unset
 
 #### Defined in
 
-[src/entity.js:131](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L131)
+[src/entity.js:131](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entity.js#L131)
 
 ___
 
@@ -216,7 +216,7 @@ Whether the value was inserted
 
 #### Defined in
 
-[src/entity.js:147](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L147)
+[src/entity.js:147](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entity.js#L147)
 
 ___
 
@@ -244,7 +244,7 @@ entity.removeValue('tags', 'a_tag');
 
 #### Defined in
 
-[src/entity.js:161](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L161)
+[src/entity.js:161](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entity.js#L161)
 
 ___
 
@@ -265,7 +265,7 @@ console.log(entity.json());
 
 #### Defined in
 
-[src/entity.js:173](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L173)
+[src/entity.js:173](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entity.js#L173)
 
 ___
 
@@ -289,7 +289,7 @@ console.log(data.children[0].name);
 
 #### Defined in
 
-[src/entity.js:188](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L188)
+[src/entity.js:188](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entity.js#L188)
 
 ___
 
@@ -313,7 +313,7 @@ True if it is
 
 #### Defined in
 
-[src/entity.js:204](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L204)
+[src/entity.js:204](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entity.js#L204)
 
 ___
 
@@ -342,7 +342,7 @@ The entity
 
 #### Defined in
 
-[src/entity.js:227](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L227)
+[src/entity.js:227](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entity.js#L227)
 
 ___
 
@@ -376,7 +376,7 @@ The entities
 
 #### Defined in
 
-[src/entity.js:262](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L262)
+[src/entity.js:262](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entity.js#L262)
 
 ___
 
@@ -405,7 +405,7 @@ The result
 
 #### Defined in
 
-[src/entity.js:301](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L301)
+[src/entity.js:301](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entity.js#L301)
 
 ___
 
@@ -435,7 +435,7 @@ editor.entities.root.depthFirst(entity => entities.push(entity));
 
 #### Defined in
 
-[src/entity.js:331](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L331)
+[src/entity.js:331](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entity.js#L331)
 
 ___
 
@@ -465,7 +465,7 @@ editor.entities.root.addComponent('model', {
 
 #### Defined in
 
-[src/entity.js:357](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L357)
+[src/entity.js:357](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entity.js#L357)
 
 ___
 
@@ -492,7 +492,7 @@ editor.entities.root.removeComponent('model');
 
 #### Defined in
 
-[src/entity.js:372](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L372)
+[src/entity.js:372](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entity.js#L372)
 
 ___
 
@@ -522,7 +522,7 @@ A promise
 
 #### Defined in
 
-[src/entity.js:453](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L453)
+[src/entity.js:458](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entity.js#L458)
 
 ___
 
@@ -556,7 +556,7 @@ door.reparent(greenHouse);
 
 #### Defined in
 
-[src/entity.js:473](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L473)
+[src/entity.js:478](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entity.js#L478)
 
 ___
 
@@ -583,7 +583,7 @@ The new entity
 
 #### Defined in
 
-[src/entity.js:490](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L490)
+[src/entity.js:495](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entity.js#L495)
 
 ___
 
@@ -601,7 +601,7 @@ The entity
 
 #### Defined in
 
-[src/entity.js:500](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L500)
+[src/entity.js:505](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entity.js#L505)
 
 ___
 
@@ -631,7 +631,7 @@ A promise
 
 #### Defined in
 
-[src/entity.js:518](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L518)
+[src/entity.js:523](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entity.js#L523)
 
 ___
 
@@ -655,7 +655,7 @@ Removes a script from the entity's script component.
 
 #### Defined in
 
-[src/entity.js:529](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L529)
+[src/entity.js:534](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entity.js#L534)
 
 ___
 
@@ -681,7 +681,7 @@ Whether the child was added
 
 #### Defined in
 
-[src/entity.js:383](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L383)
+[src/entity.js:383](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entity.js#L383)
 
 ___
 
@@ -706,7 +706,7 @@ Whether the child was added
 
 #### Defined in
 
-[src/entity.js:395](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L395)
+[src/entity.js:395](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entity.js#L395)
 
 ___
 
@@ -728,4 +728,4 @@ Removes entity from children
 
 #### Defined in
 
-[src/entity.js:419](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entity.js#L419)
+[src/entity.js:424](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entity.js#L424)

--- a/docs/classes/Guid.md
+++ b/docs/classes/Guid.md
@@ -31,7 +31,7 @@ A new GUID.
 
 #### Defined in
 
-[src/guid.js:13](https://github.com/playcanvas/editor-api/blob/a50e91b/src/guid.js#L13)
+[src/guid.js:13](https://github.com/playcanvas/editor-api/blob/1e69a27/src/guid.js#L13)
 
 ## Constructors
 

--- a/docs/classes/History.md
+++ b/docs/classes/History.md
@@ -46,7 +46,7 @@ Events.constructor
 
 #### Defined in
 
-[src/history.js:21](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L21)
+[src/history.js:21](https://github.com/playcanvas/editor-api/blob/1e69a27/src/history.js#L21)
 
 ## Methods
 
@@ -78,7 +78,7 @@ editor.history.add({
 
 #### Defined in
 
-[src/history.js:45](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L45)
+[src/history.js:45](https://github.com/playcanvas/editor-api/blob/1e69a27/src/history.js#L45)
 
 ___
 
@@ -99,7 +99,7 @@ editor.history.undo();
 
 #### Defined in
 
-[src/history.js:57](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L57)
+[src/history.js:57](https://github.com/playcanvas/editor-api/blob/1e69a27/src/history.js#L57)
 
 ___
 
@@ -120,7 +120,7 @@ editor.history.redo();
 
 #### Defined in
 
-[src/history.js:69](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L69)
+[src/history.js:69](https://github.com/playcanvas/editor-api/blob/1e69a27/src/history.js#L69)
 
 ___
 
@@ -141,7 +141,7 @@ editor.history.clear();
 
 #### Defined in
 
-[src/history.js:81](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L81)
+[src/history.js:81](https://github.com/playcanvas/editor-api/blob/1e69a27/src/history.js#L81)
 
 ## Accessors
 
@@ -157,7 +157,7 @@ Gets the current action
 
 #### Defined in
 
-[src/history.js:90](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L90)
+[src/history.js:90](https://github.com/playcanvas/editor-api/blob/1e69a27/src/history.js#L90)
 
 ___
 
@@ -173,7 +173,7 @@ Gets the last action
 
 #### Defined in
 
-[src/history.js:99](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L99)
+[src/history.js:99](https://github.com/playcanvas/editor-api/blob/1e69a27/src/history.js#L99)
 
 ___
 
@@ -189,7 +189,7 @@ Whether there are any actions to undo
 
 #### Defined in
 
-[src/history.js:108](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L108)
+[src/history.js:108](https://github.com/playcanvas/editor-api/blob/1e69a27/src/history.js#L108)
 
 • `set` **canUndo**(`value`): `void`
 
@@ -207,7 +207,7 @@ Whether there are any actions to undo
 
 #### Defined in
 
-[src/history.js:112](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L112)
+[src/history.js:112](https://github.com/playcanvas/editor-api/blob/1e69a27/src/history.js#L112)
 
 ___
 
@@ -223,7 +223,7 @@ Whether there are actions to redo
 
 #### Defined in
 
-[src/history.js:121](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L121)
+[src/history.js:121](https://github.com/playcanvas/editor-api/blob/1e69a27/src/history.js#L121)
 
 • `set` **canRedo**(`value`): `void`
 
@@ -241,4 +241,4 @@ Whether there are actions to redo
 
 #### Defined in
 
-[src/history.js:125](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L125)
+[src/history.js:125](https://github.com/playcanvas/editor-api/blob/1e69a27/src/history.js#L125)

--- a/docs/classes/Jobs.md
+++ b/docs/classes/Jobs.md
@@ -33,7 +33,7 @@ Events.constructor
 
 #### Defined in
 
-[src/jobs.js:10](https://github.com/playcanvas/editor-api/blob/a50e91b/src/jobs.js#L10)
+[src/jobs.js:10](https://github.com/playcanvas/editor-api/blob/1e69a27/src/jobs.js#L10)
 
 ## Methods
 
@@ -64,7 +64,7 @@ Returns a job id
 
 #### Defined in
 
-[src/jobs.js:27](https://github.com/playcanvas/editor-api/blob/a50e91b/src/jobs.js#L27)
+[src/jobs.js:27](https://github.com/playcanvas/editor-api/blob/1e69a27/src/jobs.js#L27)
 
 ___
 
@@ -96,4 +96,4 @@ The function stored when the job was started
 
 #### Defined in
 
-[src/jobs.js:47](https://github.com/playcanvas/editor-api/blob/a50e91b/src/jobs.js#L47)
+[src/jobs.js:47](https://github.com/playcanvas/editor-api/blob/1e69a27/src/jobs.js#L47)

--- a/docs/classes/LocalStorage.md
+++ b/docs/classes/LocalStorage.md
@@ -27,7 +27,7 @@ Constructor
 
 #### Defined in
 
-[src/localstorage.js:10](https://github.com/playcanvas/editor-api/blob/a50e91b/src/localstorage.js#L10)
+[src/localstorage.js:10](https://github.com/playcanvas/editor-api/blob/1e69a27/src/localstorage.js#L10)
 
 ## Methods
 
@@ -51,7 +51,7 @@ The value
 
 #### Defined in
 
-[src/localstorage.js:20](https://github.com/playcanvas/editor-api/blob/a50e91b/src/localstorage.js#L20)
+[src/localstorage.js:20](https://github.com/playcanvas/editor-api/blob/1e69a27/src/localstorage.js#L20)
 
 ___
 
@@ -74,7 +74,7 @@ Stores a key-value to localStorage
 
 #### Defined in
 
-[src/localstorage.js:48](https://github.com/playcanvas/editor-api/blob/a50e91b/src/localstorage.js#L48)
+[src/localstorage.js:48](https://github.com/playcanvas/editor-api/blob/1e69a27/src/localstorage.js#L48)
 
 ___
 
@@ -96,7 +96,7 @@ Removes a key from localStorage
 
 #### Defined in
 
-[src/localstorage.js:62](https://github.com/playcanvas/editor-api/blob/a50e91b/src/localstorage.js#L62)
+[src/localstorage.js:62](https://github.com/playcanvas/editor-api/blob/1e69a27/src/localstorage.js#L62)
 
 ___
 
@@ -120,4 +120,4 @@ True or false
 
 #### Defined in
 
-[src/localstorage.js:72](https://github.com/playcanvas/editor-api/blob/a50e91b/src/localstorage.js#L72)
+[src/localstorage.js:72](https://github.com/playcanvas/editor-api/blob/1e69a27/src/localstorage.js#L72)

--- a/docs/classes/Messenger.md
+++ b/docs/classes/Messenger.md
@@ -45,7 +45,7 @@ Events.constructor
 
 #### Defined in
 
-[src/messenger.js:17](https://github.com/playcanvas/editor-api/blob/a50e91b/src/messenger.js#L17)
+[src/messenger.js:17](https://github.com/playcanvas/editor-api/blob/1e69a27/src/messenger.js#L17)
 
 ## Methods
 
@@ -67,7 +67,7 @@ Connects to the messenger server.
 
 #### Defined in
 
-[src/messenger.js:46](https://github.com/playcanvas/editor-api/blob/a50e91b/src/messenger.js#L46)
+[src/messenger.js:46](https://github.com/playcanvas/editor-api/blob/1e69a27/src/messenger.js#L46)
 
 ## Accessors
 
@@ -83,4 +83,4 @@ Returns true if we are connected to the messenger server.
 
 #### Defined in
 
-[src/messenger.js:56](https://github.com/playcanvas/editor-api/blob/a50e91b/src/messenger.js#L56)
+[src/messenger.js:56](https://github.com/playcanvas/editor-api/blob/1e69a27/src/messenger.js#L56)

--- a/docs/classes/Realtime.md
+++ b/docs/classes/Realtime.md
@@ -34,7 +34,7 @@ Events.constructor
 
 #### Defined in
 
-[src/realtime.js:12](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime.js#L12)
+[src/realtime.js:12](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime.js#L12)
 
 ## Accessors
 
@@ -50,7 +50,7 @@ Gets the realtime connection
 
 #### Defined in
 
-[src/realtime.js:24](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime.js#L24)
+[src/realtime.js:24](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime.js#L24)
 
 ___
 
@@ -66,7 +66,7 @@ Gets the realtime scenes API
 
 #### Defined in
 
-[src/realtime.js:33](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime.js#L33)
+[src/realtime.js:33](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime.js#L33)
 
 ___
 
@@ -82,4 +82,4 @@ Gets the realtime assets API
 
 #### Defined in
 
-[src/realtime.js:42](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime.js#L42)
+[src/realtime.js:42](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime.js#L42)

--- a/docs/classes/RealtimeAsset.md
+++ b/docs/classes/RealtimeAsset.md
@@ -52,7 +52,7 @@ Events.constructor
 
 #### Defined in
 
-[src/realtime/asset.js:20](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/asset.js#L20)
+[src/realtime/asset.js:20](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/asset.js#L20)
 
 ## Methods
 
@@ -68,7 +68,7 @@ Loads asset from sharedb and subscribes to changes.
 
 #### Defined in
 
-[src/realtime/asset.js:34](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/asset.js#L34)
+[src/realtime/asset.js:34](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/asset.js#L34)
 
 ___
 
@@ -84,7 +84,7 @@ Unloads asset from sharedb and unsubscribes from changes.
 
 #### Defined in
 
-[src/realtime/asset.js:49](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/asset.js#L49)
+[src/realtime/asset.js:49](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/asset.js#L49)
 
 ___
 
@@ -106,7 +106,7 @@ Submits sharedb operation
 
 #### Defined in
 
-[src/realtime/asset.js:68](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/asset.js#L68)
+[src/realtime/asset.js:68](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/asset.js#L68)
 
 ___
 
@@ -129,7 +129,7 @@ sent to the server
 
 #### Defined in
 
-[src/realtime/asset.js:85](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/asset.js#L85)
+[src/realtime/asset.js:85](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/asset.js#L85)
 
 ## Accessors
 
@@ -145,7 +145,7 @@ Whether the asset is loaded
 
 #### Defined in
 
-[src/realtime/asset.js:131](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/asset.js#L131)
+[src/realtime/asset.js:131](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/asset.js#L131)
 
 ___
 
@@ -161,7 +161,7 @@ The asset data
 
 #### Defined in
 
-[src/realtime/asset.js:140](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/asset.js#L140)
+[src/realtime/asset.js:140](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/asset.js#L140)
 
 ___
 
@@ -177,7 +177,7 @@ The asset id - used in combination with branch id
 
 #### Defined in
 
-[src/realtime/asset.js:149](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/asset.js#L149)
+[src/realtime/asset.js:149](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/asset.js#L149)
 
 ___
 
@@ -193,4 +193,4 @@ The asset's unique id
 
 #### Defined in
 
-[src/realtime/asset.js:158](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/asset.js#L158)
+[src/realtime/asset.js:158](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/asset.js#L158)

--- a/docs/classes/RealtimeAssets.md
+++ b/docs/classes/RealtimeAssets.md
@@ -43,7 +43,7 @@ Events.constructor
 
 #### Defined in
 
-[src/realtime/assets.js:19](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/assets.js#L19)
+[src/realtime/assets.js:19](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/assets.js#L19)
 
 ## Methods
 
@@ -67,7 +67,7 @@ The asset
 
 #### Defined in
 
-[src/realtime/assets.js:32](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/assets.js#L32)
+[src/realtime/assets.js:32](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/assets.js#L32)
 
 ___
 
@@ -91,7 +91,7 @@ The asset
 
 #### Defined in
 
-[src/realtime/assets.js:52](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/assets.js#L52)
+[src/realtime/assets.js:52](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/assets.js#L52)
 
 ___
 
@@ -113,4 +113,4 @@ Unloads an asset
 
 #### Defined in
 
-[src/realtime/assets.js:61](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/assets.js#L61)
+[src/realtime/assets.js:61](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/assets.js#L61)

--- a/docs/classes/RealtimeConnection.md
+++ b/docs/classes/RealtimeConnection.md
@@ -52,7 +52,7 @@ Events.constructor
 
 #### Defined in
 
-[src/realtime/connection.js:20](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/connection.js#L20)
+[src/realtime/connection.js:20](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/connection.js#L20)
 
 ## Methods
 
@@ -74,7 +74,7 @@ Connect to the realtime server
 
 #### Defined in
 
-[src/realtime/connection.js:39](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/connection.js#L39)
+[src/realtime/connection.js:39](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/connection.js#L39)
 
 ___
 
@@ -90,7 +90,7 @@ Disconnect from the server
 
 #### Defined in
 
-[src/realtime/connection.js:77](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/connection.js#L77)
+[src/realtime/connection.js:77](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/connection.js#L77)
 
 ___
 
@@ -113,7 +113,7 @@ Send message to server
 
 #### Defined in
 
-[src/realtime/connection.js:91](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/connection.js#L91)
+[src/realtime/connection.js:91](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/connection.js#L91)
 
 ___
 
@@ -135,7 +135,7 @@ Sends a string to the server
 
 #### Defined in
 
-[src/realtime/connection.js:100](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/connection.js#L100)
+[src/realtime/connection.js:100](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/connection.js#L100)
 
 ___
 
@@ -160,7 +160,7 @@ The sharedb document
 
 #### Defined in
 
-[src/realtime/connection.js:113](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/connection.js#L113)
+[src/realtime/connection.js:113](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/connection.js#L113)
 
 ___
 
@@ -176,7 +176,7 @@ Start bulk subscribing to documents
 
 #### Defined in
 
-[src/realtime/connection.js:120](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/connection.js#L120)
+[src/realtime/connection.js:120](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/connection.js#L120)
 
 ___
 
@@ -192,7 +192,7 @@ Stop bulk subscribing to documents
 
 #### Defined in
 
-[src/realtime/connection.js:127](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/connection.js#L127)
+[src/realtime/connection.js:127](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/connection.js#L127)
 
 ## Accessors
 
@@ -208,7 +208,7 @@ Whether the user is connected to the server
 
 #### Defined in
 
-[src/realtime/connection.js:228](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/connection.js#L228)
+[src/realtime/connection.js:228](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/connection.js#L228)
 
 ___
 
@@ -224,7 +224,7 @@ Whether the server has authenticated the user
 
 #### Defined in
 
-[src/realtime/connection.js:237](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/connection.js#L237)
+[src/realtime/connection.js:237](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/connection.js#L237)
 
 ___
 
@@ -240,4 +240,4 @@ Gets the sharedb instance
 
 #### Defined in
 
-[src/realtime/connection.js:246](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/connection.js#L246)
+[src/realtime/connection.js:246](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/connection.js#L246)

--- a/docs/classes/RealtimeScene.md
+++ b/docs/classes/RealtimeScene.md
@@ -54,7 +54,7 @@ Events.constructor
 
 #### Defined in
 
-[src/realtime/scene.js:20](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scene.js#L20)
+[src/realtime/scene.js:20](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/scene.js#L20)
 
 ## Methods
 
@@ -70,7 +70,7 @@ Loads scene from sharedb and subscribes to changes.
 
 #### Defined in
 
-[src/realtime/scene.js:34](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scene.js#L34)
+[src/realtime/scene.js:34](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/scene.js#L34)
 
 ___
 
@@ -86,7 +86,7 @@ Unloads scene from sharedb and unsubscribes from changes.
 
 #### Defined in
 
-[src/realtime/scene.js:49](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scene.js#L49)
+[src/realtime/scene.js:49](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/scene.js#L49)
 
 ___
 
@@ -108,7 +108,7 @@ Add entity to scene
 
 #### Defined in
 
-[src/realtime/scene.js:70](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scene.js#L70)
+[src/realtime/scene.js:70](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/scene.js#L70)
 
 ___
 
@@ -130,7 +130,7 @@ Removes entity from scene (not from children of another entity)
 
 #### Defined in
 
-[src/realtime/scene.js:82](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scene.js#L82)
+[src/realtime/scene.js:82](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/scene.js#L82)
 
 ___
 
@@ -152,7 +152,7 @@ Submits sharedb operation
 
 #### Defined in
 
-[src/realtime/scene.js:94](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scene.js#L94)
+[src/realtime/scene.js:94](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/scene.js#L94)
 
 ___
 
@@ -175,7 +175,7 @@ sent to the server
 
 #### Defined in
 
-[src/realtime/scene.js:111](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scene.js#L111)
+[src/realtime/scene.js:111](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/scene.js#L111)
 
 ## Accessors
 
@@ -191,7 +191,7 @@ Whether the scene is loaded
 
 #### Defined in
 
-[src/realtime/scene.js:143](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scene.js#L143)
+[src/realtime/scene.js:143](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/scene.js#L143)
 
 ___
 
@@ -207,7 +207,7 @@ The scene data
 
 #### Defined in
 
-[src/realtime/scene.js:152](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scene.js#L152)
+[src/realtime/scene.js:152](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/scene.js#L152)
 
 ___
 
@@ -223,7 +223,7 @@ The scene id - used in combination with the branch id
 
 #### Defined in
 
-[src/realtime/scene.js:161](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scene.js#L161)
+[src/realtime/scene.js:161](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/scene.js#L161)
 
 ___
 
@@ -239,4 +239,4 @@ The scene's unique id
 
 #### Defined in
 
-[src/realtime/scene.js:170](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scene.js#L170)
+[src/realtime/scene.js:170](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/scene.js#L170)

--- a/docs/classes/RealtimeScenes.md
+++ b/docs/classes/RealtimeScenes.md
@@ -46,7 +46,7 @@ Events.constructor
 
 #### Defined in
 
-[src/realtime/scenes.js:19](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scenes.js#L19)
+[src/realtime/scenes.js:19](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/scenes.js#L19)
 
 ## Methods
 
@@ -70,7 +70,7 @@ The scene
 
 #### Defined in
 
-[src/realtime/scenes.js:33](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scenes.js#L33)
+[src/realtime/scenes.js:33](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/scenes.js#L33)
 
 ___
 
@@ -92,7 +92,7 @@ Unloads a scene
 
 #### Defined in
 
-[src/realtime/scenes.js:56](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scenes.js#L56)
+[src/realtime/scenes.js:56](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/scenes.js#L56)
 
 ## Accessors
 
@@ -108,4 +108,4 @@ The current scene
 
 #### Defined in
 
-[src/realtime/scenes.js:72](https://github.com/playcanvas/editor-api/blob/a50e91b/src/realtime/scenes.js#L72)
+[src/realtime/scenes.js:72](https://github.com/playcanvas/editor-api/blob/1e69a27/src/realtime/scenes.js#L72)

--- a/docs/classes/SceneSettings.md
+++ b/docs/classes/SceneSettings.md
@@ -51,7 +51,7 @@ True if path exists
 
 #### Defined in
 
-[src/settings/scene.js:73](https://github.com/playcanvas/editor-api/blob/a50e91b/src/settings/scene.js#L73)
+[src/settings/scene.js:73](https://github.com/playcanvas/editor-api/blob/1e69a27/src/settings/scene.js#L73)
 
 ___
 
@@ -80,7 +80,7 @@ The value
 
 #### Defined in
 
-[src/settings/scene.js:87](https://github.com/playcanvas/editor-api/blob/a50e91b/src/settings/scene.js#L87)
+[src/settings/scene.js:87](https://github.com/playcanvas/editor-api/blob/1e69a27/src/settings/scene.js#L87)
 
 ___
 
@@ -110,7 +110,7 @@ Whether the value was set
 
 #### Defined in
 
-[src/settings/scene.js:102](https://github.com/playcanvas/editor-api/blob/a50e91b/src/settings/scene.js#L102)
+[src/settings/scene.js:102](https://github.com/playcanvas/editor-api/blob/1e69a27/src/settings/scene.js#L102)
 
 ___
 
@@ -131,7 +131,7 @@ console.log(editor.settings.scene.json());
 
 #### Defined in
 
-[src/settings/scene.js:114](https://github.com/playcanvas/editor-api/blob/a50e91b/src/settings/scene.js#L114)
+[src/settings/scene.js:114](https://github.com/playcanvas/editor-api/blob/1e69a27/src/settings/scene.js#L114)
 
 ## Accessors
 
@@ -147,4 +147,4 @@ Gets the history object for this entity
 
 #### Defined in
 
-[src/settings/scene.js:123](https://github.com/playcanvas/editor-api/blob/a50e91b/src/settings/scene.js#L123)
+[src/settings/scene.js:123](https://github.com/playcanvas/editor-api/blob/1e69a27/src/settings/scene.js#L123)

--- a/docs/classes/Schema.md
+++ b/docs/classes/Schema.md
@@ -35,7 +35,7 @@ Creates new instance of API
 
 #### Defined in
 
-[src/schema.js:13](https://github.com/playcanvas/editor-api/blob/a50e91b/src/schema.js#L13)
+[src/schema.js:13](https://github.com/playcanvas/editor-api/blob/1e69a27/src/schema.js#L13)
 
 ## Accessors
 
@@ -51,7 +51,7 @@ Gets the component schema
 
 #### Defined in
 
-[src/schema.js:24](https://github.com/playcanvas/editor-api/blob/a50e91b/src/schema.js#L24)
+[src/schema.js:24](https://github.com/playcanvas/editor-api/blob/1e69a27/src/schema.js#L24)
 
 ___
 
@@ -67,7 +67,7 @@ Gets the assets schema
 
 #### Defined in
 
-[src/schema.js:33](https://github.com/playcanvas/editor-api/blob/a50e91b/src/schema.js#L33)
+[src/schema.js:33](https://github.com/playcanvas/editor-api/blob/1e69a27/src/schema.js#L33)
 
 ## Internal Methods
 
@@ -92,4 +92,4 @@ The type
 
 #### Defined in
 
-[src/schema.js:45](https://github.com/playcanvas/editor-api/blob/a50e91b/src/schema.js#L45)
+[src/schema.js:45](https://github.com/playcanvas/editor-api/blob/1e69a27/src/schema.js#L45)

--- a/docs/classes/Selection.md
+++ b/docs/classes/Selection.md
@@ -49,7 +49,7 @@ Events.constructor
 
 #### Defined in
 
-[src/selection.js:80](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L80)
+[src/selection.js:80](https://github.com/playcanvas/editor-api/blob/1e69a27/src/selection.js#L80)
 
 ## Methods
 
@@ -79,7 +79,7 @@ editor.selection.add(editor.entities.root);
 
 #### Defined in
 
-[src/selection.js:114](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L114)
+[src/selection.js:114](https://github.com/playcanvas/editor-api/blob/1e69a27/src/selection.js#L114)
 
 ___
 
@@ -109,7 +109,7 @@ editor.selection.remove(editor.entities.root);
 
 #### Defined in
 
-[src/selection.js:150](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L150)
+[src/selection.js:150](https://github.com/playcanvas/editor-api/blob/1e69a27/src/selection.js#L150)
 
 ___
 
@@ -139,7 +139,7 @@ editor.selection.toogle(editor.entities.root);
 
 #### Defined in
 
-[src/selection.js:185](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L185)
+[src/selection.js:185](https://github.com/playcanvas/editor-api/blob/1e69a27/src/selection.js#L185)
 
 ___
 
@@ -168,7 +168,7 @@ If item is in selection
 
 #### Defined in
 
-[src/selection.js:221](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L221)
+[src/selection.js:221](https://github.com/playcanvas/editor-api/blob/1e69a27/src/selection.js#L221)
 
 ___
 
@@ -196,7 +196,7 @@ editor.selection.clear();
 
 #### Defined in
 
-[src/selection.js:235](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L235)
+[src/selection.js:235](https://github.com/playcanvas/editor-api/blob/1e69a27/src/selection.js#L235)
 
 ___
 
@@ -226,7 +226,7 @@ editor.selection.set([editor.entities.root]);
 
 #### Defined in
 
-[src/selection.js:278](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L278)
+[src/selection.js:278](https://github.com/playcanvas/editor-api/blob/1e69a27/src/selection.js#L278)
 
 ## Accessors
 
@@ -248,7 +248,7 @@ const selectedEntities = editor.selection.items;
 
 #### Defined in
 
-[src/selection.js:312](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L312)
+[src/selection.js:312](https://github.com/playcanvas/editor-api/blob/1e69a27/src/selection.js#L312)
 
 ___
 
@@ -264,7 +264,7 @@ Gets the first selected item. Short for this.items[0].
 
 #### Defined in
 
-[src/selection.js:321](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L321)
+[src/selection.js:321](https://github.com/playcanvas/editor-api/blob/1e69a27/src/selection.js#L321)
 
 ___
 
@@ -280,7 +280,7 @@ Enables / disables the selection methods
 
 #### Defined in
 
-[src/selection.js:330](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L330)
+[src/selection.js:330](https://github.com/playcanvas/editor-api/blob/1e69a27/src/selection.js#L330)
 
 • `set` **enabled**(`value`): `void`
 
@@ -298,7 +298,7 @@ Enables / disables the selection methods
 
 #### Defined in
 
-[src/selection.js:334](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L334)
+[src/selection.js:334](https://github.com/playcanvas/editor-api/blob/1e69a27/src/selection.js#L334)
 
 ___
 
@@ -314,7 +314,7 @@ Gets the number of selected items
 
 #### Defined in
 
-[src/selection.js:343](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L343)
+[src/selection.js:343](https://github.com/playcanvas/editor-api/blob/1e69a27/src/selection.js#L343)
 
 ___
 
@@ -330,4 +330,4 @@ Gets the selection history
 
 #### Defined in
 
-[src/selection.js:352](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L352)
+[src/selection.js:352](https://github.com/playcanvas/editor-api/blob/1e69a27/src/selection.js#L352)

--- a/docs/classes/SelectionHistory.md
+++ b/docs/classes/SelectionHistory.md
@@ -32,7 +32,7 @@ Constructor
 
 #### Defined in
 
-[src/selection.js:14](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L14)
+[src/selection.js:14](https://github.com/playcanvas/editor-api/blob/1e69a27/src/selection.js#L14)
 
 ## Accessors
 
@@ -48,7 +48,7 @@ Disables / enables selection undo / redo
 
 #### Defined in
 
-[src/selection.js:25](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L25)
+[src/selection.js:25](https://github.com/playcanvas/editor-api/blob/1e69a27/src/selection.js#L25)
 
 • `set` **enabled**(`value`): `void`
 
@@ -66,4 +66,4 @@ Disables / enables selection undo / redo
 
 #### Defined in
 
-[src/selection.js:29](https://github.com/playcanvas/editor-api/blob/a50e91b/src/selection.js#L29)
+[src/selection.js:29](https://github.com/playcanvas/editor-api/blob/1e69a27/src/selection.js#L29)

--- a/docs/classes/Settings.md
+++ b/docs/classes/Settings.md
@@ -34,7 +34,7 @@ Events.constructor
 
 #### Defined in
 
-[src/settings.js:11](https://github.com/playcanvas/editor-api/blob/a50e91b/src/settings.js#L11)
+[src/settings.js:11](https://github.com/playcanvas/editor-api/blob/1e69a27/src/settings.js#L11)
 
 ## Accessors
 
@@ -50,4 +50,4 @@ Gets the settings for the currently loaded scene.
 
 #### Defined in
 
-[src/settings.js:22](https://github.com/playcanvas/editor-api/blob/a50e91b/src/settings.js#L22)
+[src/settings.js:22](https://github.com/playcanvas/editor-api/blob/1e69a27/src/settings.js#L22)

--- a/docs/classes/globals.md
+++ b/docs/classes/globals.md
@@ -44,7 +44,7 @@ The history API
 
 #### Defined in
 
-[src/globals.js:10](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L10)
+[src/globals.js:10](https://github.com/playcanvas/editor-api/blob/1e69a27/src/globals.js#L10)
 
 ___
 
@@ -56,7 +56,7 @@ The selection API
 
 #### Defined in
 
-[src/globals.js:17](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L17)
+[src/globals.js:17](https://github.com/playcanvas/editor-api/blob/1e69a27/src/globals.js#L17)
 
 ___
 
@@ -68,7 +68,7 @@ The schema API
 
 #### Defined in
 
-[src/globals.js:24](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L24)
+[src/globals.js:24](https://github.com/playcanvas/editor-api/blob/1e69a27/src/globals.js#L24)
 
 ___
 
@@ -80,7 +80,7 @@ The assets API
 
 #### Defined in
 
-[src/globals.js:39](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L39)
+[src/globals.js:39](https://github.com/playcanvas/editor-api/blob/1e69a27/src/globals.js#L39)
 
 ___
 
@@ -92,7 +92,7 @@ The entities API
 
 #### Defined in
 
-[src/globals.js:46](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L46)
+[src/globals.js:46](https://github.com/playcanvas/editor-api/blob/1e69a27/src/globals.js#L46)
 
 ___
 
@@ -104,7 +104,7 @@ The settings API
 
 #### Defined in
 
-[src/globals.js:53](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L53)
+[src/globals.js:53](https://github.com/playcanvas/editor-api/blob/1e69a27/src/globals.js#L53)
 
 ___
 
@@ -116,7 +116,7 @@ The current project id
 
 #### Defined in
 
-[src/globals.js:92](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L92)
+[src/globals.js:92](https://github.com/playcanvas/editor-api/blob/1e69a27/src/globals.js#L92)
 
 ___
 
@@ -128,7 +128,7 @@ The current branch id
 
 #### Defined in
 
-[src/globals.js:99](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L99)
+[src/globals.js:99](https://github.com/playcanvas/editor-api/blob/1e69a27/src/globals.js#L99)
 
 ___
 
@@ -142,7 +142,7 @@ The realtime API
 
 #### Defined in
 
-[src/globals.js:32](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L32)
+[src/globals.js:32](https://github.com/playcanvas/editor-api/blob/1e69a27/src/globals.js#L32)
 
 ___
 
@@ -154,7 +154,7 @@ The messenger API
 
 #### Defined in
 
-[src/globals.js:61](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L61)
+[src/globals.js:61](https://github.com/playcanvas/editor-api/blob/1e69a27/src/globals.js#L61)
 
 ___
 
@@ -166,7 +166,7 @@ The jobs API
 
 #### Defined in
 
-[src/globals.js:69](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L69)
+[src/globals.js:69](https://github.com/playcanvas/editor-api/blob/1e69a27/src/globals.js#L69)
 
 ___
 
@@ -178,7 +178,7 @@ The main clipboard
 
 #### Defined in
 
-[src/globals.js:77](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L77)
+[src/globals.js:77](https://github.com/playcanvas/editor-api/blob/1e69a27/src/globals.js#L77)
 
 ___
 
@@ -190,7 +190,7 @@ The user's access token
 
 #### Defined in
 
-[src/globals.js:85](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L85)
+[src/globals.js:85](https://github.com/playcanvas/editor-api/blob/1e69a27/src/globals.js#L85)
 
 ___
 
@@ -202,7 +202,7 @@ Whether this project is using legacy scripts
 
 #### Defined in
 
-[src/globals.js:107](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L107)
+[src/globals.js:107](https://github.com/playcanvas/editor-api/blob/1e69a27/src/globals.js#L107)
 
 ## Methods
 
@@ -232,7 +232,7 @@ True if the user confirmed, false otherwise
 
 #### Defined in
 
-[src/globals.js:121](https://github.com/playcanvas/editor-api/blob/a50e91b/src/globals.js#L121)
+[src/globals.js:121](https://github.com/playcanvas/editor-api/blob/1e69a27/src/globals.js#L121)
 
 ## Constructors
 

--- a/docs/classes/utils.md
+++ b/docs/classes/utils.md
@@ -36,7 +36,7 @@ A copy of the data
 
 #### Defined in
 
-[src/utils.js:13](https://github.com/playcanvas/editor-api/blob/a50e91b/src/utils.js#L13)
+[src/utils.js:13](https://github.com/playcanvas/editor-api/blob/1e69a27/src/utils.js#L13)
 
 ## Constructors
 

--- a/docs/interfaces/AssetUploadArguments.md
+++ b/docs/interfaces/AssetUploadArguments.md
@@ -27,7 +27,7 @@ The parent folder asset where the asset should be placed.
 
 #### Defined in
 
-[src/assets.js:13](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L13)
+[src/assets.js:13](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L13)
 
 ___
 
@@ -39,7 +39,7 @@ The filename of the uploaded file.
 
 #### Defined in
 
-[src/assets.js:14](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L14)
+[src/assets.js:14](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L14)
 
 ___
 
@@ -51,7 +51,7 @@ The file being uploaded.
 
 #### Defined in
 
-[src/assets.js:15](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L15)
+[src/assets.js:15](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L15)
 
 ___
 
@@ -63,7 +63,7 @@ The type of the asset we are uploading. See [here](AssetProperties.md) for avail
 
 #### Defined in
 
-[src/assets.js:16](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L16)
+[src/assets.js:16](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L16)
 
 ___
 
@@ -75,7 +75,7 @@ The name of the asset.
 
 #### Defined in
 
-[src/assets.js:17](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L17)
+[src/assets.js:17](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L17)
 
 ___
 
@@ -87,7 +87,7 @@ The tags of the asset.
 
 #### Defined in
 
-[src/assets.js:18](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L18)
+[src/assets.js:18](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L18)
 
 ___
 
@@ -99,7 +99,7 @@ The id of the source asset.
 
 #### Defined in
 
-[src/assets.js:19](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L19)
+[src/assets.js:19](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L19)
 
 ___
 
@@ -111,7 +111,7 @@ The asset data. This depends on the asset type. See [here](AssetProperties.md) f
 
 #### Defined in
 
-[src/assets.js:20](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L20)
+[src/assets.js:20](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L20)
 
 ___
 
@@ -123,7 +123,7 @@ Whether to preload the asset. Defaults to true.
 
 #### Defined in
 
-[src/assets.js:21](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L21)
+[src/assets.js:21](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L21)
 
 ___
 
@@ -135,4 +135,4 @@ If an asset id is specified then this asset will be updated instead of creating 
 
 #### Defined in
 
-[src/assets.js:22](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L22)
+[src/assets.js:22](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L22)

--- a/docs/interfaces/CreateEntityArguments.md
+++ b/docs/interfaces/CreateEntityArguments.md
@@ -27,7 +27,7 @@ The entity name
 
 #### Defined in
 
-[src/entities.js:18](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L18)
+[src/entities.js:18](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L18)
 
 ___
 
@@ -39,7 +39,7 @@ Component data. See [here](EntityProperties.md) for details on component data.
 
 #### Defined in
 
-[src/entities.js:19](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L19)
+[src/entities.js:19](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L19)
 
 ___
 
@@ -51,7 +51,7 @@ The parent Entity or its resource_id. If undefined then the root Entity will be 
 
 #### Defined in
 
-[src/entities.js:20](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L20)
+[src/entities.js:20](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L20)
 
 ___
 
@@ -63,7 +63,7 @@ Data for child entities.
 
 #### Defined in
 
-[src/entities.js:21](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L21)
+[src/entities.js:21](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L21)
 
 ___
 
@@ -75,7 +75,7 @@ Tags for the Entity.
 
 #### Defined in
 
-[src/entities.js:22](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L22)
+[src/entities.js:22](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L22)
 
 ___
 
@@ -87,7 +87,7 @@ Whether the Entity should be enabled.
 
 #### Defined in
 
-[src/entities.js:23](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L23)
+[src/entities.js:23](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L23)
 
 ___
 
@@ -99,7 +99,7 @@ The resource_id of the Entity. Leave undefined to generate a new one.
 
 #### Defined in
 
-[src/entities.js:24](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L24)
+[src/entities.js:24](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L24)
 
 ___
 
@@ -111,7 +111,7 @@ The position of the Entity in local space.
 
 #### Defined in
 
-[src/entities.js:25](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L25)
+[src/entities.js:25](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L25)
 
 ___
 
@@ -123,7 +123,7 @@ The rotation of the Entity in local space (euler angles in degrees).
 
 #### Defined in
 
-[src/entities.js:26](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L26)
+[src/entities.js:26](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L26)
 
 ___
 
@@ -135,4 +135,4 @@ The scale of the Entity in local space.
 
 #### Defined in
 
-[src/entities.js:27](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L27)
+[src/entities.js:27](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L27)

--- a/docs/interfaces/HistoryAction.md
+++ b/docs/interfaces/HistoryAction.md
@@ -20,7 +20,7 @@ The action name
 
 #### Defined in
 
-[src/history.js:7](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L7)
+[src/history.js:7](https://github.com/playcanvas/editor-api/blob/1e69a27/src/history.js#L7)
 
 ___
 
@@ -32,7 +32,7 @@ The undo function
 
 #### Defined in
 
-[src/history.js:8](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L8)
+[src/history.js:8](https://github.com/playcanvas/editor-api/blob/1e69a27/src/history.js#L8)
 
 ___
 
@@ -44,4 +44,4 @@ The redo function
 
 #### Defined in
 
-[src/history.js:9](https://github.com/playcanvas/editor-api/blob/a50e91b/src/history.js#L9)
+[src/history.js:9](https://github.com/playcanvas/editor-api/blob/1e69a27/src/history.js#L9)

--- a/docs/interfaces/ReparentArguments.md
+++ b/docs/interfaces/ReparentArguments.md
@@ -20,7 +20,7 @@ The entity to reparent
 
 #### Defined in
 
-[src/entities.js:34](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L34)
+[src/entities.js:34](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L34)
 
 ___
 
@@ -32,7 +32,7 @@ The new parent for the entity
 
 #### Defined in
 
-[src/entities.js:35](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L35)
+[src/entities.js:35](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L35)
 
 ___
 
@@ -44,4 +44,4 @@ The child index of the entity under the new parent
 
 #### Defined in
 
-[src/entities.js:36](https://github.com/playcanvas/editor-api/blob/a50e91b/src/entities.js#L36)
+[src/entities.js:36](https://github.com/playcanvas/editor-api/blob/1e69a27/src/entities.js#L36)

--- a/docs/interfaces/SceneImportSettings.md
+++ b/docs/interfaces/SceneImportSettings.md
@@ -29,7 +29,7 @@ throughout the whole project instead of just the same folder. Defaults to true.
 
 #### Defined in
 
-[src/assets.js:38](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L38)
+[src/assets.js:38](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L38)
 
 ___
 
@@ -41,7 +41,7 @@ Whether to overwrite existing model or create a new one. Defaults to true.
 
 #### Defined in
 
-[src/assets.js:40](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L40)
+[src/assets.js:40](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L40)
 
 ___
 
@@ -53,7 +53,7 @@ Whether to overwrite existing animations or create new ones. Defaults to true.
 
 #### Defined in
 
-[src/assets.js:41](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L41)
+[src/assets.js:41](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L41)
 
 ___
 
@@ -65,7 +65,7 @@ Whether to overwrite existing materials or create new ones. Defaults to true.
 
 #### Defined in
 
-[src/assets.js:42](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L42)
+[src/assets.js:42](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L42)
 
 ___
 
@@ -77,7 +77,7 @@ Whether to overwrite existing textures or create new ones. Defaults to true.
 
 #### Defined in
 
-[src/assets.js:43](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L43)
+[src/assets.js:43](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L43)
 
 ___
 
@@ -89,7 +89,7 @@ Whether to resize embedded textures to power of 2. Defaults to true.
 
 #### Defined in
 
-[src/assets.js:44](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L44)
+[src/assets.js:44](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L44)
 
 ___
 
@@ -101,7 +101,7 @@ Whether to convert models to GLB. Defaults to true.
 
 #### Defined in
 
-[src/assets.js:45](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L45)
+[src/assets.js:45](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L45)
 
 ___
 
@@ -113,7 +113,7 @@ The desired animation sample rate. Defaults to 10.
 
 #### Defined in
 
-[src/assets.js:46](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L46)
+[src/assets.js:46](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L46)
 
 ___
 
@@ -125,7 +125,7 @@ The animation curve tolerance. Defaults to 0.
 
 #### Defined in
 
-[src/assets.js:47](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L47)
+[src/assets.js:47](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L47)
 
 ___
 
@@ -137,7 +137,7 @@ Whether to enable cubic curves. Defaults to false.
 
 #### Defined in
 
-[src/assets.js:48](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L48)
+[src/assets.js:48](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L48)
 
 ___
 
@@ -149,4 +149,4 @@ Whether to use the fbx filename for animation names. Defaults to false.
 
 #### Defined in
 
-[src/assets.js:49](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L49)
+[src/assets.js:49](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L49)

--- a/docs/interfaces/TextureImportSettings.md
+++ b/docs/interfaces/TextureImportSettings.md
@@ -19,7 +19,7 @@ Whether to resize the texture to power of 2.
 
 #### Defined in
 
-[src/assets.js:29](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L29)
+[src/assets.js:29](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L29)
 
 ___
 
@@ -32,4 +32,4 @@ throughout the whole project instead of just the same folder.
 
 #### Defined in
 
-[src/assets.js:30](https://github.com/playcanvas/editor-api/blob/a50e91b/src/assets.js#L30)
+[src/assets.js:30](https://github.com/playcanvas/editor-api/blob/1e69a27/src/assets.js#L30)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "editor-api",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "editor-api",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "The PlayCanvas Editor API",
   "main": "index.js",
   "module": "index.mjs",

--- a/src/entity.js
+++ b/src/entity.js
@@ -39,6 +39,11 @@ class Entity extends Events {
         }
         if (data.template_ent_ids) {
             observerData.template_ent_ids = data.template_ent_ids;
+
+            // consistency check
+            if (!data.template_ent_ids[observerData.resource_id]) {
+                console.error(`Entity ${observerData.resource_id} has invalid template references and needs to be recreated`);
+            }
         }
 
         this._observer = new Observer(observerData);

--- a/src/entity.js
+++ b/src/entity.js
@@ -39,11 +39,6 @@ class Entity extends Events {
         }
         if (data.template_ent_ids) {
             observerData.template_ent_ids = data.template_ent_ids;
-
-            // consistency check
-            if (!data.template_ent_ids[observerData.resource_id]) {
-                console.error(`Entity ${observerData.resource_id} has invalid template references and needs to be recreated`);
-            }
         }
 
         this._observer = new Observer(observerData);

--- a/test/api/test-entities.js
+++ b/test/api/test-entities.js
@@ -1107,6 +1107,7 @@ describe('api.Entities tests', function () {
         expect(newTemplateEntIds[dup.children[0].get('resource_id')]).to.equal(templateEntIds[child.get('resource_id')]);
         delete newTemplateEntIds[dup.get('resource_id')];
         delete newTemplateEntIds[dup.children[0].get('resource_id')];
+        expect(Object.keys(newTemplateEntIds)[0]).to.not.equal(missing);
         expect(newTemplateEntIds[Object.keys(newTemplateEntIds)[0]]).to.equal(templateEntIds[missing]);
 
         const dupChild = dup.children[0];
@@ -1114,6 +1115,7 @@ describe('api.Entities tests', function () {
         expect(Object.keys(newChildTemplateEntIds).length).to.equal(2);
         expect(newChildTemplateEntIds[dupChild.get('resource_id')]).to.equal(childTemplateEntIds[child.get('resource_id')]);
         delete newChildTemplateEntIds[dupChild.get('resource_id')];
+        expect(Object.keys(newChildTemplateEntIds)[0]).to.not.equal(missing2);
         expect(newChildTemplateEntIds[Object.keys(newChildTemplateEntIds)[0]]).to.equal(childTemplateEntIds[missing2]);
     });
 

--- a/test/api/test-entities.js
+++ b/test/api/test-entities.js
@@ -1074,6 +1074,49 @@ describe('api.Entities tests', function () {
         expect(newTemplateEntIds[Object.keys(newTemplateEntIds)[0]]).to.equal(templateEntIds[missing]);
     });
 
+    it('duplicate updates nested template_ent_ids', async function () {
+        api.globals.schema = new api.Schema(schema);
+
+        const root = api.globals.entities.create();
+        const entity = api.globals.entities.create({ parent: root });
+        const child = api.globals.entities.create({ parent: entity });
+
+        // create template_ent_ids for parent
+        const templateEntIds = {};
+        templateEntIds[entity.get('resource_id')] = api.Guid.create();
+        templateEntIds[child.get('resource_id')] = api.Guid.create();
+
+        // create a missing reference as well
+        const missing = api.Guid.create();
+        templateEntIds[missing] = api.Guid.create();
+        entity.set('template_ent_ids', templateEntIds);
+
+        // create template_ent_ids for child
+        const childTemplateEntIds = {};
+        childTemplateEntIds[child.get('resource_id')] = api.Guid.create();
+        // create a missing reference as well
+        const missing2 = api.Guid.create();
+        childTemplateEntIds[missing2] = api.Guid.create();
+        child.set('template_ent_ids', childTemplateEntIds);
+
+        const dup = await entity.duplicate();
+
+        const newTemplateEntIds = dup.get('template_ent_ids');
+        expect(Object.keys(newTemplateEntIds).length).to.equal(3);
+        expect(newTemplateEntIds[dup.get('resource_id')]).to.equal(templateEntIds[entity.get('resource_id')]);
+        expect(newTemplateEntIds[dup.children[0].get('resource_id')]).to.equal(templateEntIds[child.get('resource_id')]);
+        delete newTemplateEntIds[dup.get('resource_id')];
+        delete newTemplateEntIds[dup.children[0].get('resource_id')];
+        expect(newTemplateEntIds[Object.keys(newTemplateEntIds)[0]]).to.equal(templateEntIds[missing]);
+
+        const dupChild = dup.children[0];
+        const newChildTemplateEntIds = dupChild.get('template_ent_ids');
+        expect(Object.keys(newChildTemplateEntIds).length).to.equal(2);
+        expect(newChildTemplateEntIds[dupChild.get('resource_id')]).to.equal(childTemplateEntIds[child.get('resource_id')]);
+        delete newChildTemplateEntIds[dupChild.get('resource_id')];
+        expect(newChildTemplateEntIds[Object.keys(newChildTemplateEntIds)[0]]).to.equal(childTemplateEntIds[missing2]);
+    });
+
     it('duplicate filters children if parents are selected', async function () {
         api.globals.schema = new api.Schema(schema);
 

--- a/test/api/test-entities.js
+++ b/test/api/test-entities.js
@@ -1094,6 +1094,9 @@ describe('api.Entities tests', function () {
         // create template_ent_ids for child
         const childTemplateEntIds = {};
         childTemplateEntIds[child.get('resource_id')] = api.Guid.create();
+        // add missing reference from parent - this should be preserved in the new template_ent_ids
+        childTemplateEntIds[missing] = templateEntIds[missing];
+
         // create a missing reference as well
         const missing2 = api.Guid.create();
         childTemplateEntIds[missing2] = api.Guid.create();
@@ -1107,14 +1110,21 @@ describe('api.Entities tests', function () {
         expect(newTemplateEntIds[dup.children[0].get('resource_id')]).to.equal(templateEntIds[child.get('resource_id')]);
         delete newTemplateEntIds[dup.get('resource_id')];
         delete newTemplateEntIds[dup.children[0].get('resource_id')];
-        expect(Object.keys(newTemplateEntIds)[0]).to.not.equal(missing);
-        expect(newTemplateEntIds[Object.keys(newTemplateEntIds)[0]]).to.equal(templateEntIds[missing]);
+
+        const newMissingKey = Object.keys(newTemplateEntIds)[0];
+
+        expect(newMissingKey).to.not.equal(missing);
+        expect(newTemplateEntIds[newMissingKey]).to.equal(templateEntIds[missing]);
+
 
         const dupChild = dup.children[0];
         const newChildTemplateEntIds = dupChild.get('template_ent_ids');
-        expect(Object.keys(newChildTemplateEntIds).length).to.equal(2);
+        expect(Object.keys(newChildTemplateEntIds).length).to.equal(3);
         expect(newChildTemplateEntIds[dupChild.get('resource_id')]).to.equal(childTemplateEntIds[child.get('resource_id')]);
         delete newChildTemplateEntIds[dupChild.get('resource_id')];
+        expect(newChildTemplateEntIds[newMissingKey]).to.equal(childTemplateEntIds[missing]);
+        delete newChildTemplateEntIds[newMissingKey];
+
         expect(Object.keys(newChildTemplateEntIds)[0]).to.not.equal(missing2);
         expect(newChildTemplateEntIds[Object.keys(newChildTemplateEntIds)[0]]).to.equal(childTemplateEntIds[missing2]);
     });


### PR DESCRIPTION
This PR fixes a bug where duplicating a template entity that contains nested templates, did not update template_ent_ids for the nested templates, leading to other bugs further down the line. 
