### PR TITLE
Fix missing thumbnails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "editor-api",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "editor-api",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "The PlayCanvas Editor API",
   "main": "index.js",
   "module": "index.mjs",

--- a/src/asset.js
+++ b/src/asset.js
@@ -46,6 +46,13 @@ class Asset extends Events {
 
         this._observer.on('has_thumbnail:set', this._resetThumbnailUrls.bind(this));
 
+        // this can happen when the asset is created without a type because
+        // the type is not yet available e.g. when listing Assets using the REST API
+        // or when fields are set out of order e.g. has_thumbnail set before type
+        if (!data.type) {
+            this._observer.once('type:set', this._resetThumbnailUrls.bind(this));
+        }
+
         this._suspendOnSet = false;
         this._observer.on('*:set', this._onSet.bind(this));
 


### PR DESCRIPTION
Fix texture thumbnails not being set when the asset `type` is set after `has_thumbnail`

Fixes https://github.com/playcanvas/editor/issues/577