### PR TITLE
Follow-up fix for duplicating entities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "editor-api",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "editor-api",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "The PlayCanvas Editor API",
   "main": "index.js",
   "module": "index.mjs",

--- a/src/entities/duplicate.js
+++ b/src/entities/duplicate.js
@@ -20,6 +20,24 @@ const USE_BACKEND_LIMIT = 500;
  * @param {object} duplicatedIdsMap - Map of old id -> new id
  */
 function updateDuplicatedEntityReferences(newEntity, oldEntity, duplicatedIdsMap) {
+    // remap template_ent_ids for template instances
+    newEntity.depthFirst((entity) => {
+        const templateEntIds = entity.get('template_ent_ids');
+        if (templateEntIds) {
+            const newTemplateEntIds = {};
+            for (const oldId in templateEntIds) {
+                if (duplicatedIdsMap[oldId]) {
+                    newTemplateEntIds[duplicatedIdsMap[oldId]] = templateEntIds[oldId];
+                }
+            }
+
+            const history = entity.history.enabled;
+            entity.history.enabled = false;
+            entity.set('template_ent_ids', newTemplateEntIds);
+            entity.history.enabled = history;
+        }
+    });
+
     // update entity references
     const entityReferences = findEntityReferencesInComponents(newEntity);
     for (const id in entityReferences) {
@@ -299,10 +317,10 @@ async function duplicateEntities(entities, options) {
             previousSelection = api.selection.items;
         }
 
-        const duplicatedIdsMap = {};
-
         // duplicate
         entities.forEach((entity) => {
+            const duplicatedIdsMap = {};
+
             const newEntity = duplicateEntity(
                 entity,
                 entity.parent,
@@ -314,27 +332,6 @@ async function duplicateEntities(entities, options) {
             updateDuplicatedEntityReferences(newEntity, entity, duplicatedIdsMap);
 
             newEntities.push(newEntity);
-        });
-
-        // update template_ent_ids for duplicated entities
-        newEntities.forEach((entity) => {
-            entity.depthFirst((entity) => {
-                // remap template_ent_ids for template instances
-                const templateEntIds = entity.get('template_ent_ids');
-                if (templateEntIds) {
-                    const newTemplateEntIds = {};
-                    for (const oldId in templateEntIds) {
-                        if (duplicatedIdsMap[oldId]) {
-                            newTemplateEntIds[duplicatedIdsMap[oldId]] = templateEntIds[oldId];
-                        }
-                    }
-
-                    const history = entity.history.enabled;
-                    entity.history.enabled = false;
-                    entity.set('template_ent_ids', newTemplateEntIds);
-                    entity.history.enabled = history;
-                }
-            });
         });
 
         if (options.history && api.history) {

--- a/test/api/test-entities.js
+++ b/test/api/test-entities.js
@@ -1039,6 +1039,26 @@ describe('api.Entities tests', function () {
             }
         });
 
+        const child = api.globals.entities.create({ parent: entity });
+        child.addComponent('script', {
+            scripts: {
+                test: {
+                    attributes: {
+                        entity: id,
+                        entityArray: [id, id],
+                        json: {
+                            entity: id,
+                            entityArray: [id, id]
+                        },
+                        jsonArray: [{
+                            entity: id,
+                            entityArray: [id, id]
+                        }]
+                    }
+                }
+            }
+        });
+
         const dup = await entity.duplicate();
         const newId = dup.get('resource_id');
         expect(dup.get('components.script.scripts.test.attributes.entity')).to.equal(newId);
@@ -1047,6 +1067,14 @@ describe('api.Entities tests', function () {
         expect(dup.get('components.script.scripts.test.attributes.json.entityArray')).to.deep.equal([newId, newId]);
         expect(dup.get('components.script.scripts.test.attributes.jsonArray.0.entity')).to.equal(newId);
         expect(dup.get('components.script.scripts.test.attributes.jsonArray.0.entityArray')).to.deep.equal([newId, newId]);
+
+        const dupChild = dup.children[0];
+        expect(dupChild.get('components.script.scripts.test.attributes.entity')).to.equal(newId);
+        expect(dupChild.get('components.script.scripts.test.attributes.entityArray')).to.deep.equal([newId, newId]);
+        expect(dupChild.get('components.script.scripts.test.attributes.json.entity')).to.equal(newId);
+        expect(dupChild.get('components.script.scripts.test.attributes.json.entityArray')).to.deep.equal([newId, newId]);
+        expect(dupChild.get('components.script.scripts.test.attributes.jsonArray.0.entity')).to.equal(newId);
+        expect(dupChild.get('components.script.scripts.test.attributes.jsonArray.0.entityArray')).to.deep.equal([newId, newId]);
     });
 
     it('duplicate updates template_ent_ids', async function () {


### PR DESCRIPTION
This previous PR https://github.com/playcanvas/editor-api/pull/31 made sure that any children of duplicated entities get their `template_ent_ids` updated. However it also changed the scope of the `duplicatedIdsMap` variable. Before, it was per duplicated entity. But that PR made it so that if multiple entities are duplicated they would all use the same `duplicatedIdsMap`. So that map would keep on growing but also it would hold ids of entities that belonged to the tree of previously duplicated entities.

This PR  keeps the code as it was before https://github.com/playcanvas/editor-api/pull/31  but with the added fix of child templates. Having said that the effect of not merging the current PR should mostly be performance related if you have selected a lot of entities to duplicate. It should not affect functionality.