### PR TITLE
Set observer.history field for scene settings (expected by the Editor)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@playcanvas/editor-api",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playcanvas/editor-api",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "The PlayCanvas Editor API",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/settings/scene.js
+++ b/src/settings/scene.js
@@ -37,9 +37,10 @@ class SceneSettings extends Events {
 
         this._history = new ObserverHistory({
             item: this._observer,
-            prefix: 'settings',
+            prefix: 'settings.',
             history: api.history
         });
+        this._observer.history = this._history;
     }
 
     /**


### PR DESCRIPTION
This PR sets the observer.history field for scene settings because it was omitted in the initial PR