### PR TITLE
Add TypeScript declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .npmrc
 dist
+types

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "karma-spec-reporter": "^0.0.34",
         "mocha": "^10.1.0",
         "rollup": "^3.2.3",
+        "rollup-plugin-dts": "^5.0.0",
         "sinon": "^14.0.1",
         "typedoc": "^0.23.17",
         "typedoc-plugin-markdown": "^3.13.6",
@@ -4497,6 +4498,18 @@
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
       "dev": true
     },
+    "node_modules/magic-string": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
+      "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/marked": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.1.tgz",
@@ -5304,6 +5317,28 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-dts": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-5.0.0.tgz",
+      "integrity": "sha512-OO8ayCvuJCKaQSShyVTARxGurVVk4ulzbuvz+0zFd1f93vlnWFU5pBMT7HFeS6uj7MvvZLx4kUAarGATSU1+Ng==",
+      "dev": true,
+      "dependencies": {
+        "magic-string": "^0.26.7"
+      },
+      "engines": {
+        "node": ">=v14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Swatinem"
+      },
+      "optionalDependencies": {
+        "@babel/code-frame": "^7.18.6"
+      },
+      "peerDependencies": {
+        "rollup": "^3.0.0",
+        "typescript": "^4.1"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5507,6 +5542,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "node_modules/spdx-exceptions": {
       "version": "2.3.0",
@@ -9482,6 +9523,15 @@
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
       "dev": true
     },
+    "magic-string": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
+      "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
     "marked": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.1.tgz",
@@ -10066,6 +10116,16 @@
         "fsevents": "~2.3.2"
       }
     },
+    "rollup-plugin-dts": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-5.0.0.tgz",
+      "integrity": "sha512-OO8ayCvuJCKaQSShyVTARxGurVVk4ulzbuvz+0zFd1f93vlnWFU5pBMT7HFeS6uj7MvvZLx4kUAarGATSU1+Ng==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.18.6",
+        "magic-string": "^0.26.7"
+      }
+    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -10222,6 +10282,12 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
     "spdx-exceptions": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
   "bugs": {
     "url": "https://github.com/playcanvas/editor-api/issues"
   },
@@ -40,6 +41,7 @@
     "karma-spec-reporter": "^0.0.34",
     "mocha": "^10.1.0",
     "rollup": "^3.2.3",
+    "rollup-plugin-dts": "^5.0.0",
     "sinon": "^14.0.1",
     "typedoc": "^0.23.17",
     "typedoc-plugin-markdown": "^3.13.6",
@@ -50,6 +52,7 @@
     "test:debug": "karma start test/karma.conf.js --single-run=false --browsers Chrome",
     "build": "rollup -c",
     "build:docs": "typedoc --options typedoc.json",
+    "build:types": "tsc index.js --outDir types --allowJs --declaration --emitDeclarationOnly && rollup -c --environment target:types",
     "lint": "eslint --ext .js src"
   }
 }

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -60,10 +60,5 @@ const types = {
 };
 
 export default (args) => {
-    const envTarget = process.env.target ? process.env.target.toLowerCase() : null;
-    if (envTarget === 'types') {
-        return [types];
-    }
-
-    return [umd, module];
+    return process.env.target === 'types' ? [types] : [umd, module];
 };

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,4 +1,5 @@
 import babel from '@rollup/plugin-babel';
+import dts from 'rollup-plugin-dts';
 
 const umd = {
     external: ['@playcanvas/observer'],
@@ -46,4 +47,23 @@ const module = {
     }
 };
 
-export default [umd, module];
+const types = {
+    input: 'types/index.d.ts',
+    output: [{
+        file: 'dist/index.d.ts',
+        footer: 'export as namespace editor;',
+        format: 'es'
+    }],
+    plugins: [
+        dts()
+    ]
+};
+
+export default (args) => {
+    const envTarget = process.env.target ? process.env.target.toLowerCase() : null;
+    if (envTarget === 'types') {
+        return [types];
+    }
+
+    return [umd, module];
+};


### PR DESCRIPTION
Add support for building TypeScript declarations. Run `npm run build:types` to build them.

Fixes #47 