### PR TITLE
On duplicate undo, ensure that we get the entities in the scene to delete

### DIFF
--- a/src/entities/duplicate.js
+++ b/src/entities/duplicate.js
@@ -345,10 +345,6 @@ async function duplicateEntities(entities, options) {
                         return entity.latest();
                     });
 
-                    newEntities = newEntities.filter((entity) => {
-                        return entity !== null;
-                    });
-
                     // remember previous entities
                     previous = {};
                     newEntities.forEach((entity) => {

--- a/src/entities/duplicate.js
+++ b/src/entities/duplicate.js
@@ -340,6 +340,15 @@ async function duplicateEntities(entities, options) {
             api.history.add({
                 name: 'duplicate entities',
                 undo: () => {
+                    // make sure we get the entities that are in the scene
+                    newEntities = newEntities.map((entity) => {
+                        return entity.latest();
+                    });
+
+                    newEntities = newEntities.filter((entity) => {
+                        return entity !== null;
+                    });
+
                     // remember previous entities
                     previous = {};
                     newEntities.forEach((entity) => {


### PR DESCRIPTION
Fixes: https://github.com/playcanvas/editor/issues/758

Bug repro steps:

- Create a new blank project
- Delete all entities
- Create new entity
- Duplicate the newly created entity
- Delete the duplicate entity
- Undo all the operations

Notice that the entities originally created aren't undone and when we look at the parent Entities children in data, there are more children then what's in the scene 

<img width="589" alt="image" src="https://user-images.githubusercontent.com/16639049/203528479-46dcd140-1417-4b94-b617-18622917c1d8.png">

<img width="255" alt="image" src="https://user-images.githubusercontent.com/16639049/203528502-0e0ae266-6188-460f-856a-78a6cc493e86.png">

This is because the undo action stores references to the Entities that are created so that it can delete them on the undo.

However, the delete action removes them from the scene and so the duplicate undo action references become invalid as they are no longer in the scene.

When we undo the delete, a new Entity is created in the scene with the same data (like the GUID).

The fix in this PR is to use entities.latest() in duplicate undo to get that new Entity created from the delete undo from the scene so we can remove them correctly