### PR TITLE
option for entity delete to wait till ops submitted

### DIFF
--- a/src/entities/delete.js
+++ b/src/entities/delete.js
@@ -187,7 +187,7 @@ async function deleteEntities(entities, options = {}) {
             } else {
                 resolve();
             }
-        });   
+        });
     }
 }
 

--- a/src/entities/delete.js
+++ b/src/entities/delete.js
@@ -180,7 +180,9 @@ async function deleteEntities(entities, options = {}) {
 
     if (options.waitSubmitted) {
 
-        // wait for scene ops to finish
+        // wait for scene operational transforms to finish:
+        // sometimes we need to execute the next operation on the backend
+        // just after delete - use waitSubmitted to guarantee the order of operations
         await new Promise((resolve) => {
             if (api.realtime.scenes.current) {
                 api.realtime.scenes.current.whenNothingPending(resolve);

--- a/src/entities/delete.js
+++ b/src/entities/delete.js
@@ -77,6 +77,7 @@ function rememberPrevious(entities) {
  * @param {Entity[]|Entity} entities - The entities
  * @param {object} [options] - Options
  * @param {boolean} [options.history] - Whether to record a history action. Defaults to true.
+ * @param {boolean} [options.waitSubmitted] - Whether to wait till ops submitted.
  */
 async function deleteEntities(entities, options = {}) {
     if (options.history === undefined) {
@@ -176,6 +177,19 @@ async function deleteEntities(entities, options = {}) {
             }
         });
     }
+
+
+    if (options.waitSubmitted) {
+
+        // wait for scene ops to finish 
+        await new Promise((resolve) => {
+            if (api.realtime.scenes.current) {
+                api.realtime.scenes.current.whenNothingPending(resolve);
+            } else {
+                resolve();
+            }
+        });   
+    } 
 }
 
 export { deleteEntities };

--- a/src/entities/delete.js
+++ b/src/entities/delete.js
@@ -178,10 +178,9 @@ async function deleteEntities(entities, options = {}) {
         });
     }
 
-
     if (options.waitSubmitted) {
 
-        // wait for scene ops to finish 
+        // wait for scene ops to finish
         await new Promise((resolve) => {
             if (api.realtime.scenes.current) {
                 api.realtime.scenes.current.whenNothingPending(resolve);
@@ -189,7 +188,7 @@ async function deleteEntities(entities, options = {}) {
                 resolve();
             }
         });   
-    } 
+    }
 }
 
 export { deleteEntities };


### PR DESCRIPTION
deleteEntities now supports waitSubmitted option to wait till all scene ops submitted. 