### PR TITLE
encode asset urls in editor

### DIFF
--- a/src/asset.js
+++ b/src/asset.js
@@ -312,7 +312,7 @@ class Asset extends Events {
      * @returns {string} The file URL
      */
     static getFileUrl(id, filename) {
-        return `/api/assets/${id}/file/${filename}?branchId=${api.branchId}`;
+        return `/api/assets/${id}/file/${encodeURIComponent(filename)}?branchId=${api.branchId}`;
     }
 }
 


### PR DESCRIPTION
fix for this one - 

If a texture has a # in the asset name, it cannot be downloaded from the editor or rendered in the view
https://github.com/playcanvas/editor/issues/814
