### PR TITLE
Generate ESM boilerplate

### DIFF
--- a/src/assets/createScript.js
+++ b/src/assets/createScript.js
@@ -75,12 +75,12 @@ ${className}.prototype.update = function(dt) {
 
 };
 
-// swap method called for script hot-reloading
-// inherit your script state here
+// uncomment the swap method to enable hot-reloading for this script
+// update the method body to copy state from the old instance
 // ${className}.prototype.swap = function(old) { };
 
-// to learn more about script anatomy, please read:
-// https://developer.playcanvas.com/en/user-manual/scripting/
+// learn more about scripting here:
+// https://developer.playcanvas.com/user-manual/scripting/
     `.trim();
 }
 

--- a/src/assets/createScript.js
+++ b/src/assets/createScript.js
@@ -103,7 +103,7 @@ export class ${className} extends pc.ScriptType {
     // swap(old) { };
 }
 
-// learn more about script anatomy here:
+// learn more about scripting here:
 // https://developer.playcanvas.com/user-manual/scripting/
     `.trim();
 

--- a/src/assets/createScript.js
+++ b/src/assets/createScript.js
@@ -1,7 +1,8 @@
 const VALID_FILENAME = /^([^0-9.#<>$+%!`&='{}@\\/:*?"<>|\n])([^#<>$+%!`&='{}@\\/:*?"<>|\n])*$/i;
 
 /**
- * Creates filename and script content from provided arguments.
+ * Creates filename and script content from provided arguments. If the provide filename contains a '.mjs'
+ * suffix, it will generate an ESM based class syntax.
  *
  * @param {string} filename - The desired filename.
  * @param {string} text - The desired contents of the script. If not provided boilerplate code will be used.
@@ -97,15 +98,15 @@ export class ${className} extends pc.ScriptType {
 
     }
 
-    // swap method called for script hot-reloading
-    // inherit your script state here
+    // uncomment the swap method to enable hot-reloading for this script
+    // update the method body to copy state from the old instance
     // swap(old) { };
 }
 
-// to learn more about script anatomy, please read:
-// https://developer.playcanvas.com/en/user-manual/scripting/
+// learn more about script anatomy here:
+// https://developer.playcanvas.com/user-manual/scripting/
     `.trim();
-    
+
 }
 
 export { createScript };

--- a/src/assets/createScript.js
+++ b/src/assets/createScript.js
@@ -50,8 +50,9 @@ function createScript(filename, text) {
     if (!/.js$/i.test(filename)) {
         filename += '.js';
     }
-
-    const content = text || createBoilerplate(className, scriptName);
+    const isEsm = filename.endsWith('.mjs');
+    const boilerPlateGenerator = isEsm ? createEsmBoilerplate : createBoilerplate;
+    const content = text || boilerPlateGenerator(className, scriptName);
 
     return {
         filename,
@@ -80,6 +81,31 @@ ${className}.prototype.update = function(dt) {
 // to learn more about script anatomy, please read:
 // https://developer.playcanvas.com/en/user-manual/scripting/
     `.trim();
+}
+
+function createEsmBoilerplate(className, scriptName) {
+    return `
+export class ${className} extends pc.ScriptType {
+
+    static name = '${scriptName}';
+
+    initialize() {
+
+    }
+
+    update() {
+
+    }
+
+    // swap method called for script hot-reloading
+    // inherit your script state here
+    // swap(old) { };
+}
+
+// to learn more about script anatomy, please read:
+// https://developer.playcanvas.com/en/user-manual/scripting/
+    `.trim();
+    
 }
 
 export { createScript };

--- a/test/api/test-assets.js
+++ b/test/api/test-assets.js
@@ -32,12 +32,12 @@ ${className}.prototype.update = function(dt) {
 
 };
 
-// swap method called for script hot-reloading
-// inherit your script state here
+// uncomment the swap method to enable hot-reloading for this script
+// update the method body to copy state from the old instance
 // ${className}.prototype.swap = function(old) { };
 
-// to learn more about script anatomy, please read:
-// https://developer.playcanvas.com/en/user-manual/scripting/
+// learn more about scripting here:
+// https://developer.playcanvas.com/user-manual/scripting/
         `.trim();
     }
 


### PR DESCRIPTION
This PR adds the ability to conditionally generate ESM based class boilerplate when using `createScript()`. If the provided filename contains the `.mjs` suffix it will generate code based on the following boilerplate;

```javascript
export class ClassName extends pc.ScriptType {

    static name = 'Script Name';

    initialize() {

    }

    update() {

    }

    // uncomment the swap method to enable hot-reloading for this script
    // update the method body to copy state from the old instance
    // swap(old) { };
}

// learn more about scripting here:
// https://developer.playcanvas.com/user-manual/scripting/
```