### PR TITLE
Updates ESM boilerplate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playcanvas/editor-api",
-  "version": "1.0.29",
+  "version": "1.0.31",
   "author": "PlayCanvas <support@playcanvas.com>",
   "homepage": "https://github.com/playcanvas/editor-api#readme",
   "description": "The PlayCanvas Editor API",

--- a/src/assets/createScript.js
+++ b/src/assets/createScript.js
@@ -86,9 +86,9 @@ ${className}.prototype.update = function(dt) {
 
 function createEsmBoilerplate(className, scriptName) {
     return `
-export class ${className} extends pc.ScriptType {
+import { Script } from 'playcanvas';
 
-    static name = '${scriptName}';
+export class ${className} extends Script {
 
     initialize() {
 


### PR DESCRIPTION
Updating the editor-api ESM boiler plate to include new `attributes` over `attributesDefinition`, using `Script` over `ScriptType`. Also bumping to .31 patch as an earlier release was published with no updates