### PR TITLE
Add TypeScript boilerplate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@playcanvas/editor-api",
-      "version": "1.0.38",
+      "version": "1.0.40",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.23.7",

--- a/src/assets/createScript.js
+++ b/src/assets/createScript.js
@@ -2,8 +2,8 @@ const VALID_FILENAME = /^[^0-9.#<>$+%!`&='{}@\\/:*?"|\n][^#<>$+%!`&='{}@\\/:*?"|
 const extensionToBoilerplateMap = new Map([
     ['.js', createBoilerplate],
     ['.mjs', createEsmBoilerplate],
-    ['.ts', createTsBoilerplate],
-])
+    ['.ts', createTsBoilerplate]
+]);
 const validExtensions = Array.from(extensionToBoilerplateMap.keys());
 
 /**
@@ -62,10 +62,10 @@ function createScript(filename, text) {
 
     // Extract extension from filename
     const extension = filename.slice(filename.lastIndexOf('.'));
-    
+
     // Get the correct boilerplate generator based on the file extension
     const boilerPlateGenerator = extensionToBoilerplateMap.get(extension);
-    
+
     const content = text || boilerPlateGenerator(className, scriptName);
 
     return {
@@ -122,6 +122,7 @@ export class ${className} extends Script {
     }
 }
 `.trim();
+}
 
 function createTsBoilerplate(className, scriptName) {
     return `

--- a/src/assets/createScript.js
+++ b/src/assets/createScript.js
@@ -1,4 +1,10 @@
 const VALID_FILENAME = /^[^0-9.#<>$+%!`&='{}@\\/:*?"|\n][^#<>$+%!`&='{}@\\/:*?"|\n]*$/;
+const extensionToBoilerplateMap = new Map([
+    ['.js', createBoilerplate],
+    ['.mjs', createEsmBoilerplate],
+    ['.ts', createTsBoilerplate],
+])
+const validExtensions = Array.from(extensionToBoilerplateMap.keys());
 
 /**
  * Creates filename and script content from provided arguments. If the provide filename contains a '.mjs'
@@ -49,11 +55,17 @@ function createScript(filename, text) {
         filename = `${scriptName}.js`;
     }
 
-    if (!/.js$/i.test(filename)) {
+    const hasValidExtension = validExtensions.some(ext => filename.endsWith(ext));
+    if (!hasValidExtension) {
         filename += '.js';
     }
-    const isEsm = filename.endsWith('.mjs');
-    const boilerPlateGenerator = isEsm ? createEsmBoilerplate : createBoilerplate;
+
+    // Extract extension from filename
+    const extension = filename.slice(filename.lastIndexOf('.'));
+    
+    // Get the correct boilerplate generator based on the file extension
+    const boilerPlateGenerator = extensionToBoilerplateMap.get(extension);
+    
     const content = text || boilerPlateGenerator(className, scriptName);
 
     return {
@@ -107,6 +119,32 @@ export class ${className} extends Script {
      * @param {number} dt - The delta time in seconds since the last frame.
      */
     update(dt) {
+    }
+}
+`.trim();
+
+function createTsBoilerplate(className, scriptName) {
+    return `
+import { Script } from 'playcanvas';
+
+/**
+ * The {@link https://api.playcanvas.com/classes/Engine.Script.html | Script} class is
+ * the base class for all PlayCanvas scripts. Learn more about writing scripts in the
+ * {@link https://developer.playcanvas.com/user-manual/scripting/ | scripting guide}.
+ */
+export class ${className} extends Script {
+    /**
+     * Called when the script is about to run for the first time.
+     */
+    initialize(): void {
+    }
+
+    /**
+     * Called for enabled (running state) scripts on each tick.
+     * 
+     * @param {number} dt - The delta time in seconds since the last frame.
+     */
+    update(dt: number): void {
     }
 }
 `.trim();


### PR DESCRIPTION
This PR adds support for generating TS boilerplate in the `createScript()` method. The boilerplate is an extension of the `.mjs` with type annotations.

```typescript
import { Script } from 'playcanvas';

/**
 * The {@link https://api.playcanvas.com/classes/Engine.Script.html | Script} class is
 * the base class for all PlayCanvas scripts. Learn more about writing scripts in the
 * {@link https://developer.playcanvas.com/user-manual/scripting/ | scripting guide}.
 */
export class MyClass extends Script {
    /**
     * Called when the script is about to run for the first time.
     */
    initialize(): void {
    }

    /**
     * Called for enabled (running state) scripts on each tick.
     * 
     * @param {number} dt - The delta time in seconds since the last frame.
     */
    update(dt: number): void {
    }
}
```