### PR TITLE
Observer Updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/eslint-parser": "^7.23.3",
         "@babel/preset-env": "^7.23.8",
         "@playcanvas/eslint-config": "2.0.8",
-        "@playcanvas/observer": "^1.5.1",
+        "@playcanvas/observer": "^1.6.1",
         "@rollup/plugin-babel": "^6.0.4",
         "@rollup/plugin-commonjs": "^26.0.1",
         "@rollup/plugin-node-resolve": "^15.2.3",
@@ -2032,11 +2032,14 @@
       }
     },
     "node_modules/@playcanvas/observer": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@playcanvas/observer/-/observer-1.5.1.tgz",
-      "integrity": "sha512-0y4OQOtwhgCvFaNlhLgi4ycSeOdnp0Frf4R+8eewxtfZQW1Muox2lkUGoMywoRRLhaRjUMdaxQN1o53lNjlB9w==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@playcanvas/observer/-/observer-1.6.1.tgz",
+      "integrity": "sha512-toAH2LLMdUXIY21Sh+nIxV2kHNQQncIXLjiwqk5Pq+oRVMJ4cznbqfHhGVzkFdoAQfbWQ5vJDSEglE9ImHqKgA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@publint/pack": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@babel/eslint-parser": "^7.23.3",
     "@babel/preset-env": "^7.23.8",
     "@playcanvas/eslint-config": "2.0.8",
-    "@playcanvas/observer": "^1.5.1",
+    "@playcanvas/observer": "^1.6.1",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",
@@ -67,6 +67,7 @@
     "docs": "typedoc",
     "lint": "eslint src rollup.config.mjs",
     "lint:fix": "eslint src rollup.config.mjs --fix",
+    "type:check": "tsc --noEmit",
     "publint": "publint"
   },
   "engines": {

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -385,7 +385,7 @@ class Asset extends Events {
         this._observer.apiAsset = this;
         this._observer.addEmitter(this);
 
-        (this._observer as any).latestFn = () => {
+        this._observer.latestFn = () => {
             const latest = api.assets.get(this.get('id'));
             return latest && latest._observer;
         };
@@ -509,7 +509,7 @@ class Asset extends Events {
      * @returns {boolean} Whether the value was inserted
      */
     insert(path: any, value: any, index: any) {
-        return (this._observer as any).insert(path, value, index, undefined, undefined);
+        return this._observer.insert(path, value, index);
     }
 
     /**
@@ -520,7 +520,7 @@ class Asset extends Events {
      * @returns {boolean} Whether the value was removed
      */
     removeValue(path: any, value: any) {
-        return (this._observer as any).removeValue(path, value, undefined, undefined);
+        return this._observer.removeValue(path, value);
     }
 
     /**
@@ -641,6 +641,13 @@ class Asset extends Events {
      */
     replace(asset: Asset, options: any = {}) {
         replace(this, asset, options);
+    }
+
+    /**
+     * The observer object for this asset.
+     */
+    get observer() {
+        return this._observer;
     }
 
     /**

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -173,9 +173,9 @@ class Assets extends Events {
 
         this._uniqueIdToItemId = {};
 
-        (this._assets as any) = new ObserverList({
+        this._assets = new ObserverList({
             index: 'id',
-            sorted: ((a: any, b: any) => {
+            sorted: (a: any, b: any) => {
                 const f = +(b._data.type === 'folder') - +(a._data.type === 'folder');
                 if (f !== 0) {
                     return f;
@@ -186,7 +186,7 @@ class Assets extends Events {
                     return -1;
                 }
                 return 0;
-            }) as any
+            }
         });
 
         this._parseScriptCallback = null;
@@ -262,7 +262,7 @@ class Assets extends Events {
      * @returns {Asset} The asset
      */
     get(id: number) {
-        const a = (this._assets as any).get(id);
+        const a = this._assets.get(id);
         return a ? a.apiAsset : null;
     }
 
@@ -283,7 +283,7 @@ class Assets extends Events {
      * @returns {Asset[]} The assets
      */
     list() {
-        return (this._assets as any).array().map((a: { apiAsset: any; }) => a.apiAsset);
+        return this._assets.array().map((a: { apiAsset: any; }) => a.apiAsset);
     }
 
     /**
@@ -330,18 +330,18 @@ class Assets extends Events {
     add(asset: Asset) {
         asset._initializeHistory();
 
-        const pos = (this._assets as any).add((asset as any)._observer);
+        const pos = this._assets.add(asset.observer);
         if (pos === null) return;
 
         const id = asset.get('id');
         this._uniqueIdToItemId[asset.get('uniqueId')] = id;
 
-        (asset as any)._observer.on('name:set', (name: string, oldName: string) => {
+        asset.observer.on('name:set', (name: string, oldName: string) => {
             name = (name || '').toLowerCase();
             oldName = (oldName || '').toLowerCase();
 
-            const ind = (this._assets as any).data.indexOf((asset as any)._observer);
-            let pos = (this._assets as any).positionNextClosest((asset as any)._observer, (a: any, b: any) => {
+            const ind = this._assets.data.indexOf(asset.observer);
+            let pos = this._assets.positionNextClosest(asset.observer, (a: any, b: any) => {
                 const f = +(b._data.type === 'folder') - +(a._data.type === 'folder');
 
                 if (f !== 0) {
@@ -357,7 +357,7 @@ class Assets extends Events {
 
             });
 
-            if (pos === -1 && (ind + 1) === (this._assets as any).data.length) {
+            if (pos === -1 && (ind + 1) === this._assets.data.length) {
                 return;
             }
 
@@ -369,7 +369,7 @@ class Assets extends Events {
                 pos--;
             }
 
-            (this._assets as any).move((asset as any)._observer, pos);
+            this._assets.move(asset.observer, pos);
             this.emit('move', asset, pos);
         });
 
@@ -384,12 +384,12 @@ class Assets extends Events {
      * @param {Asset} asset - The asset
      */
     remove(asset: Asset) {
-        if (!(this._assets as any).has((asset as any)._observer)) return;
+        if (!this._assets.has(asset.observer)) return;
 
-        (this._assets as any).remove((asset as any)._observer);
+        this._assets.remove(asset.observer);
 
         delete this._uniqueIdToItemId[asset.get('uniqueId')];
-        (asset as any)._observer.destroy();
+        asset.observer.destroy();
 
         if (api.realtime) {
             api.realtime.assets.unload(asset.get('uniqueId'));
@@ -408,7 +408,7 @@ class Assets extends Events {
         const assets = this.list();
         if (!assets.length) return;
 
-        (this._assets as any).clear();
+        this._assets.clear();
 
         let i = assets.length;
         while (i--) {
@@ -425,7 +425,7 @@ class Assets extends Events {
      * @returns {Asset[]} The assets
      */
     filter(fn: Function) {
-        return (this._assets as any).data
+        return this._assets.data
         .filter((observer: { apiAsset: any; }) => fn(observer.apiAsset))
         .map((observer: { apiAsset: any; }) => observer.apiAsset);
     }
@@ -437,7 +437,7 @@ class Assets extends Events {
      * @returns {Asset} The asset
      */
     findOne(fn: Function) {
-        const result = (this._assets as any).data.find((observer: { apiAsset: any; }) => fn(observer.apiAsset));
+        const result = this._assets.data.find((observer: { apiAsset: any; }) => fn(observer.apiAsset));
         return result ? result.apiAsset : null;
     }
 

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -121,7 +121,7 @@ class Entities extends Events {
      * ```
      */
     get(id: string) {
-        const e = (this._entities as any).get(id);
+        const e = this._entities.get(id);
         return e ? e.apiEntity : null;
     }
 
@@ -136,7 +136,7 @@ class Entities extends Events {
      * ```
      */
     list() {
-        return (this._entities as any).array().map((e: { apiEntity: any; }) => e.apiEntity);
+        return this._entities.array().map((e: { apiEntity: any; }) => e.apiEntity);
     }
 
     /**
@@ -153,7 +153,7 @@ class Entities extends Events {
             return;
         }
 
-        (this._entities as any).add((entity as any)._observer);
+        this._entities.add(entity.observer);
         if (!entity.get('parent')) {
             if (this._root) {
                 console.error(`More than one root entities in Scene. Current root is Entity "${this._root.get('name')}" [${this._root.get('resource_id')}] but Entity "${entity.get('name')}" [${id}] also has a null parent`);
@@ -212,8 +212,8 @@ class Entities extends Events {
 
         // remove from observer list
         try {
-            (this._entities as any).remove((entity as any)._observer);
-            (entity as any)._observer.destroy();
+            this._entities.remove(entity.observer);
+            entity.observer.destroy();
         } catch (err) {
             console.error(err);
         }
@@ -244,8 +244,8 @@ class Entities extends Events {
             });
         }
 
-        (this._entities as any).remove((entity as any)._observer);
-        (entity as any)._observer.destroy();
+        this._entities.remove(entity.observer);
+        entity.observer.destroy();
 
         if (this._root === entity) {
             this._root = null;
@@ -262,7 +262,7 @@ class Entities extends Events {
     clear() {
         this._root = null;
         const entities = this.list();
-        (this._entities as any).clear();
+        this._entities.clear();
 
         if (api.selection) {
             if (api.selection.items[0] instanceof Entity)  {
@@ -274,7 +274,7 @@ class Entities extends Events {
         }
 
         entities.forEach((entity: any) => {
-            (entity as any)._observer.destroy();
+            entity.observer.destroy();
             this.emit('remove', entity);
         });
 

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -604,7 +604,7 @@ class Entity extends Events {
      * ```
      */
     insert(path: string, value: any, index: number) {
-        return (this._observer as any).insert(path, value, index, undefined, undefined);
+        return this._observer.insert(path, value, index);
     }
 
     /**
@@ -619,7 +619,7 @@ class Entity extends Events {
      * ```
      */
     removeValue(path: string, value: any) {
-        return (this._observer as any).removeValue(path, value, undefined, undefined);
+        return this._observer.removeValue(path, value);
     }
 
     /**
@@ -885,7 +885,7 @@ class Entity extends Events {
         let history = entity.history.enabled;
         entity.history.enabled = false;
         try {
-            (entity as any)._observer.set('parent', null, true); // silent set otherwise we run into C3 error
+            entity.observer.set('parent', null, true); // silent set otherwise we run into C3 error
         } catch (err) {
             console.error(`Error when setting parent to null for entity ${entity.get('resource_id')}`);
             console.error(err);
@@ -993,6 +993,13 @@ class Entity extends Events {
      */
     removeScript(scriptName: string, options: object = {}) {
         api.entities.removeScript([this], scriptName, options);
+    }
+
+    /**
+     * The observer object for this entity.
+     */
+    get observer() {
+        return this._observer;
     }
 
     /**

--- a/src/history.ts
+++ b/src/history.ts
@@ -55,7 +55,7 @@ class History extends Events {
      * ```
      */
     addAndExecute(action: HistoryAction) {
-        (this._history as any).addAndExecute(action);
+        this._history.addAndExecute(action);
     }
 
     /**

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -7,7 +7,7 @@ import { SettingsSchema } from './schema/settings';
  * Provides methods to access the Editor schema.
  */
 class Schema {
-    private _schema: object;
+    private _schema: any;
 
     private _assetsSchema: AssetsSchema;
 
@@ -20,12 +20,19 @@ class Schema {
     /**
      * Creates new instance of API
      */
-    constructor(schema: object) {
+    constructor(schema: any) {
         this._schema = schema;
         this._assetsSchema = new AssetsSchema(this);
         this._componentSchema = new ComponentSchema(this);
         this._sceneSchema = new SceneSchema(this);
         this._settingsSchema = new SettingsSchema(this);
+    }
+
+    /**
+     * Gets the schema
+     */
+    get schema() {
+        return this._schema;
     }
 
     /**

--- a/src/schema/assets.ts
+++ b/src/schema/assets.ts
@@ -15,7 +15,7 @@ class AssetsSchema {
      */
     constructor(schema: Schema) {
         this._schemaApi = schema;
-        this._schema = (this._schemaApi as any)._schema;
+        this._schema = this._schemaApi.schema;
     }
 
     /**

--- a/src/schema/components.ts
+++ b/src/schema/components.ts
@@ -17,7 +17,7 @@ class ComponentSchema {
      */
     constructor(schema: Schema) {
         this._schemaApi = schema;
-        this._schema = (this._schemaApi as any)._schema.scene.entities.$of.components;
+        this._schema = this._schemaApi.schema.scene.entities.$of.components;
     }
 
     _resolveLazyDefaults(defaults: Record<string, any>) {

--- a/src/schema/scene.ts
+++ b/src/schema/scene.ts
@@ -17,7 +17,7 @@ class SceneSchema {
      */
     constructor(schema: Schema) {
         this._schemaApi = schema;
-        this._schema = (this._schemaApi as any)._schema.scene;
+        this._schema = this._schemaApi.schema.scene;
     }
 
     _getDefaultData(obj: Record<string, any>) {

--- a/src/schema/settings.ts
+++ b/src/schema/settings.ts
@@ -17,7 +17,7 @@ class SettingsSchema {
      */
     constructor(schema: Schema) {
         this._schemaApi = schema;
-        this._schema = (this._schemaApi as any)._schema.settings;
+        this._schema = this._schemaApi.schema.settings;
     }
 
     _getDefaultData(obj: Record<string, any>, scope: string) {

--- a/src/settings/scene.ts
+++ b/src/settings/scene.ts
@@ -63,7 +63,7 @@ class SceneSettings extends Events {
         }
 
         if (this._history) {
-            (this._history as any).destroy();
+            this._history.destroy();
         }
 
         this._history = new ObserverHistory({
@@ -84,7 +84,7 @@ class SceneSettings extends Events {
         this._initializeObserver();
 
         this._history.enabled = false;
-        (this._observer as any).patch(scene.data.settings, undefined);
+        this._observer.patch(scene.data.settings);
         this._history.enabled = true;
 
         this.emit('load');


### PR DESCRIPTION
- Updated Observer to 1.6.1
- Removed unnecessary casting to `any`