### PR TITLE
Adds scriptName to ESM template

### DIFF
--- a/src/assets/create-script.ts
+++ b/src/assets/create-script.ts
@@ -107,6 +107,9 @@ import { Script } from 'playcanvas';
  * {@link https://developer.playcanvas.com/user-manual/scripting/ | scripting guide}.
  */
 export class ${className} extends Script {
+
+    static scriptName = "${scriptName}"
+
     /**
      * Called when the script is about to run for the first time.
      */
@@ -134,6 +137,9 @@ import { Script } from 'playcanvas';
  * {@link https://developer.playcanvas.com/user-manual/scripting/ | scripting guide}.
  */
 export class ${className} extends Script {
+
+    static scriptName = "${scriptName}"
+
     /**
      * Called when the script is about to run for the first time.
      */


### PR DESCRIPTION
ESM Scripts now require a `scriptName` field. See https://github.com/playcanvas/engine/pull/7593

This updates the boiler plate to include this new field.