### PR TITLE
Copying entities will also add clipboard data

### DIFF
--- a/src/entities/copy.ts
+++ b/src/entities/copy.ts
@@ -226,13 +226,22 @@ function copyEntities(entities: Entity[]) {
         legacy_scripts: api.hasLegacyScripts,
         hierarchy: {},
         assets: {},
-        type: 'entity'
+        type: 'entity',
+        value: entities.length === 1 ? null : []
     };
 
     // build index
     const selection: Record<string, Entity> = {};
     for (let i = 0; i < entities.length; i++) {
-        selection[entities[i].get('resource_id')] = entities[i];
+        const resourceId = entities[i].get('resource_id');
+
+        selection[resourceId] = entities[i];
+
+        if (entities.length > 1) {
+            data.value.push(resourceId);
+        } else {
+            data.value = resourceId;
+        }
     }
 
     sortEntities(entities);

--- a/test/api/test-entities.js
+++ b/test/api/test-entities.js
@@ -1233,7 +1233,8 @@ describe('api.Entities tests', function () {
                 [e.get('resource_id')]: e.json()
             },
             assets: {},
-            type: 'entity'
+            type: 'entity',
+            value: e.get('resource_id')
         }));
     });
 
@@ -1259,7 +1260,8 @@ describe('api.Entities tests', function () {
                 [e2.get('resource_id')]: e2Json
             },
             assets: {},
-            type: 'entity'
+            type: 'entity',
+            value: [e.get('resource_id'), e2.get('resource_id')]
         }));
     });
 
@@ -1285,7 +1287,8 @@ describe('api.Entities tests', function () {
                 [e2.get('resource_id')]: e2Json
             },
             assets: {},
-            type: 'entity'
+            type: 'entity',
+            value: [e.get('resource_id'), e2.get('resource_id')]
         }));
     });
 
@@ -1345,7 +1348,8 @@ describe('api.Entities tests', function () {
                     type: assets[3].get('type')
                 }
             },
-            type: 'entity'
+            type: 'entity',
+            value: [e.get('resource_id'), e2.get('resource_id')]
         }));
     });
 
@@ -1397,7 +1401,8 @@ describe('api.Entities tests', function () {
                 [e.get('resource_id')]: e.json()
             },
             assets: {},
-            type: 'entity'
+            type: 'entity',
+            value: e.get('resource_id')
         };
 
         for (let i = 0; i < assets.length; i++) {
@@ -1451,7 +1456,8 @@ describe('api.Entities tests', function () {
                 [e.get('resource_id')]: e.json()
             },
             assets: {},
-            type: 'entity'
+            type: 'entity',
+            value: e.get('resource_id')
         };
 
         for (let i = 0; i < assets.length; i++) {


### PR DESCRIPTION
Partly fixes https://github.com/playcanvas/editor/issues/1369

When copying entities from hierarchy, will now add clipboard data, so it can be pasted in inspector attributes.
Very useful when need to set multiple entities from hierarchy onto attribute entity array field.

https://github.com/user-attachments/assets/951d30dc-122a-49e7-b6cf-cf40a9cc9fa2

